### PR TITLE
Fix S3 URL when using Content Delivery URL

### DIFF
--- a/src/Adapters/AwsS3.php
+++ b/src/Adapters/AwsS3.php
@@ -29,7 +29,7 @@ class AwsS3 extends Flysystem implements UploadAdapter
         $settings = app()->make(Settings::class);
 
         if ($cdnUrl = $settings->get('cdnUrl')) {
-            $file->url = sprintf('%s/%s', $cdnUrl, $file->url);
+            $file->url = sprintf('%s/%s', $cdnUrl, Arr::get($this->meta, 'path', $file->path));
         } else {
             $region = $this->adapter->getClient()->getRegion();
             $bucket = $this->adapter->getBucket();


### PR DESCRIPTION
When using CDN and S3, the URL generated does not include the path of the file in the generated URL. It is because it is referencing `$file->url` in the `generateUrl` method, which is empty/null.

PR fixes the issue, by replacing `$file->url` with the `path`.