### PR TITLE
Correctly orientate an image with exif data

### DIFF
--- a/src/Processors/ImageProcessor.php
+++ b/src/Processors/ImageProcessor.php
@@ -54,6 +54,8 @@ class ImageProcessor implements Processable
             if ($this->settings->get('addsWatermarks')) {
                 $this->watermark($image);
             }
+            
+            $image->orientate();
 
             @file_put_contents(
                 $upload->getRealPath(),


### PR DESCRIPTION
An image uploaded with exif orientation metadata is now saved correctly.

Originally reported by a giffgaff member:

> {username} mentioned this again at https://community.giffgaff.com/d/33030918-unable-to-upload-portrait-photo-always-auto-rotated-to-landscape and gave me a link to a photo which always uploades as landscape, despite being clearly intended to be portrait.

> The original is downloadable from https://photos.app.goo.gl/Cvz4nsok9VzPDc1r7 -- if you download the photo from there you will see it still shows as portrait (in a windows 10 folder, it might not do everywhere) but uploads to the forum 'sideways'




> I opened the original in aftershot pro and looked at the metadata:



> As you see, that camera is saving the image with an exif "width" that's greater than its "height" as if it's a landscape photo. But is also adding an exif orientation to instruct that the image should be rotated clockwise into portrait format, which the forum is not currently doing.