### PR TITLE
move upload button into markdown toolbar

### DIFF
--- a/js/src/forum/components/UploadButton.js
+++ b/js/src/forum/components/UploadButton.js
@@ -9,26 +9,47 @@ export default class UploadButton extends Component {
      */
     init() {
         // the service type handling uploads
-        this.textAreaObj = null;
+        this.textAreaObj = this.props.textAreaObj;
 
         // initial state of the button
         this.loading = false;
+    }
+
+    // replaces button label
+    title() {
+        return this.loading ? app.translator.trans('flagrow-upload.forum.states.loading') : app.translator.trans('flagrow-upload.forum.buttons.attach');
+    }
+
+    /** 
+     *  Tooltip shouldn't trigger on focus while open file dialog is open (hover only)
+     */
+    config(isInitialized) {
+        if (isInitialized) return;
+        this.$().tooltip({trigger: 'hover'}); // 
+    }
+
+    /**
+     *  Button click fix also addresses tooltip issues with open dialog
+     */
+    clicked() {
+        this.$().tooltip('hide');
     }
 
     /**
      * Show the actual Upload Button.
      *
      * @returns {*}
-     */
+     */ 
     view() {
-        return m('div', {className: 'Button hasIcon flagrow-upload-button Button--icon'}, [
-            this.loading ? LoadingIndicator.component({className: 'Button-icon'}) : icon('far fa-file', {className: 'Button-icon'}),
-            m('span', {className: 'Button-label'}, this.loading ? app.translator.trans('flagrow-upload.forum.states.loading') : app.translator.trans('flagrow-upload.forum.buttons.attach')),
+        return m('button', { className: 'Button Button--icon flagrow-upload-button Button--link', title: this.title()}, [
+            this.loading ? LoadingIndicator.component({className: 'flagrow-small-loading'}) : icon('far fa-file'),
             m('form#flagrow-upload-form', [
                 m('input', {
                     type: 'file',
                     multiple: true,
-                    onchange: this.process.bind(this)
+                    onchange: this.process.bind(this),
+                    onclick: this.clicked.bind(this),
+                    disabled: this.loading  // prevent users from interrupting upload
                 })
             ])
         ]);
@@ -40,8 +61,8 @@ export default class UploadButton extends Component {
      * @param e
      */
     process(e) {
-        // get the file from the input field
 
+        // get the file from the input field
         var files = $(e.target)[0].files;
 
         // set the button in the loading state (and redraw the element!)
@@ -100,6 +121,7 @@ export default class UploadButton extends Component {
         setTimeout(() => {
             document.getElementById("flagrow-upload-form").reset();
             this.loading = false;
+            m.redraw(); // stops loading icon getting stuck after upload
         }, 1000);
     }
 }

--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -11,29 +11,6 @@ app.initializers.add('flagrow-upload', app => {
         drag,
         clipboard;
 
-    extend(TextEditor.prototype, 'controlItems', function (items) {
-        // check whether the user can upload images. If not, returns.
-        if (!app.forum.attribute('canUpload')) return;
-
-        // create and add the button
-        uploadButton = new UploadButton;
-        uploadButton.textAreaObj = this;
-        items.add('flagrow-upload', uploadButton, 0);
-
-        // animate the button on hover: shows the label
-        $('.Button-label', '.item-flagrow-upload > div').hide();
-        $('.item-flagrow-upload > div').hover(
-            function () {
-                $('.Button-label', this).show();
-                $(this).removeClass('Button--icon')
-            },
-            function () {
-                $('.Button-label', this).hide();
-                $(this).addClass('Button--icon')
-            }
-        );
-    });
-
     extend(TextEditor.prototype, 'configTextarea', function() {
         // check whether the user can upload images. If not, returns.
         if (!app.forum.attribute('canUpload')) return;
@@ -43,6 +20,30 @@ app.initializers.add('flagrow-upload', app => {
         }
         if (!clipboard) {
             clipboard = new PasteClipboard(uploadButton);
+        }
+    });
+
+    extend(TextEditor.prototype, 'toolbarItems', function (items) {
+        // check whether the user can upload images, or has no markdown extension installed.
+        if ((!app.forum.attribute('canUpload') || (!items.has('markdown')))) return;
+
+        // scan markdown props via image icon identifier 
+        let markdown = items.get('markdown'), markdownButtons, imageButton;
+        markdownButtons = markdown.props.children; 
+
+        markdownButtons.forEach(btn => {
+            if ((typeof btn.props !== 'undefined') && (btn.props !== null) &&
+                (typeof btn.props.icon !== 'undefined') && (btn.props.icon !== null) &&
+                (btn.props.icon === 'fas fa-image')) {
+                    imageButton = btn;
+                }
+        });
+
+        let imageButtonIndex = markdownButtons.indexOf(imageButton); 
+        if (imageButtonIndex > 0) {     
+            // create the new button and pass this input to props
+            uploadButton =  UploadButton.component({title: app.translator.trans('flagrow-upload.forum.buttons.attach'), textAreaObj: this }); 
+            markdownButtons[imageButtonIndex] = uploadButton;
         }
     });
 

--- a/resources/less/forum/upload.less
+++ b/resources/less/forum/upload.less
@@ -13,6 +13,12 @@
         opacity: 0;
         filter: alpha(opacity=0);
     }
+
+    .LoadingIndicator {
+        transform: scale(0.70) !important;
+    } 
+
+
 }
 
 .Composer.flagrow-upload-dragging {

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -1,90 +1,99 @@
 flagrow-upload:
-  admin:
-    buttons:
-      save: Save settings
-    help_texts:
-      description: |
-        Set up uploading services and preferences.
-      disable-download-logging: |
-        Disable logging every download made by users of your forum. Keeping it enabled allows you to view the number of downloads and other metrics in the nearby future.
-      disable-hotlink-protection: |
-        Hotlink protection prevents opening downloads from other sites. Current method requires a csrf token and post id.
-      download_templates: |
-        Download templates are how uploads are shown on your forum, eg like previews, buttons. Currently available:
-      mime_types: |
-        Please configure your mapping here. Each mime type regular expression will be handled by a specific upload adapter and download template.
-      resize: |
-        Choose whether you want to resize your images before they get uploaded. You can choose a maximum width and height, in pixels. The resizing process keeps the aspect ratio of the images.
-      watermark: |
-        Choose whether images will have a watermark added during upload. Watermarks are added to non-gifs based on your preferences below.
-    labels:
-      aws-s3:
-        bucket: Bucket
-        key: Key
-        region: Region
-        secret: Secret
-        title: AWS S3 storage settings
-      disable-download-logging:
-        title: Disable logging downloads
-        toggle: Disable
-      disable-hotlink-protection:
-        title: Disable hotlink protection
-        toggle: Disable
-      imgur:
-        client_id: Imgur client ID
-        title: Imgur image storage settings
-      local:
-        cdn_url: Content Delivery URL (prefixes files)
-        title: Local storage settings
-      ovh-svfs:
-        container: Container
-        password: Password
-        region: Region
-        tenantid: Tenant ID
-        title: OVH SVFS storage settings
-        username: Username
-      qiniu:
-        title: Qiniu storage settings
-        key: Key
-        secret: Secret
-        bucket: Bucket
-      preferences:
-        max_file_size: Maximum file size (in kilobytes)
-        mime_types: 'Configure your mime type, upload adapter mapping'
-        title: General preferences
-      resize:
-        max_height: Maximum image height
-        max_width: Maximum image width
-        title: Image resize
-        toggle: Resize images
-      watermark:
-        file: Upload your watermark image
-        position: Watermark position
-        title: Watermark images
-        toggle: Watermark images
-    permissions:
-      download_label: Download files
-      upload_label: Upload files
-    templates:
-      file: Default file download template
-      file_description: |
-        Shows the file name and some general information. Proxies downloads through php, allowing for statistics gathering and hotlink protection.
-      image: Default image download template
-      image-preview: Complete image preview template
-      image-preview_description: |
-        Shows the complete image in-line. No download functionality, no statistics are gathered and hotlink protection is ignored.
-      image_description: |
-        Shows a thumbnail of the image and proxies download through php. Allowing statistics to be gathered and hotlink protection.
-    upload_methods:
-      aws-s3: Amazon S3
-      imgur: Imgur
-      local: Local
-      ovh-svfs: OVH SVFS
-      qiniu: QiNiu
-  forum:
-    buttons:
-      attach: Attach
-    states:
-      error: Error
-      loading: Loading
-      success: Success
+    forum:
+        buttons:
+            attach: Attach a file
+        states:
+            loading: Loading
+            success: Success
+            error: Error
+    admin:
+        templates:
+            image: Default image download template
+            image_description: >
+                Shows a thumbnail of the image and proxies download through php.
+                Allowing statistics to be gathered and hotlink protection.
+            file: Default file download template
+            file_description: >
+                Shows the file name and some general information. Proxies downloads
+                through php, allowing for statistics gathering and hotlink protection.
+            image-preview: Complete image preview template
+            image-preview_description: >
+                Shows the complete image in-line. No download functionality, no statistics
+                are gathered and hotlink protection is ignored.
+        permissions:
+            upload_label: Upload files
+            download_label: Download files
+        upload_methods:
+            local: Local
+            aws-s3: Amazon S3
+            imgur: Imgur
+            ovh-svfs: OVH SVFS
+        labels:
+            preferences:
+                title: General preferences
+                max_file_size: Maximum file size (in kilobytes)
+                mime_types: Configure your mime type, upload adapter mapping
+            resize:
+                title: Image resize
+                toggle: Resize images
+                max_width: Maximum image width
+                max_height: Maximum image height
+            watermark:
+                title: Watermark images
+                toggle: Watermark images
+                position: Watermark position
+                file: Upload your watermark image
+            local:
+                title: Local storage settings
+                cdn_url: Content Delivery URL (prefixes files)
+            imgur:
+                title: Imgur image storage settings
+                client_id: Imgur client ID
+            aws-s3:
+                title: AWS S3 storage settings
+                key: Key
+                secret: Secret
+                bucket: Bucket
+                region: Region
+            ovh-svfs:
+                title: OVH SVFS storage settings
+                container: Container
+                tenantid: Tenant ID
+                username: Username
+                password: Password
+                region: Region
+            disable-hotlink-protection:
+                title: Disable hotlink protection
+                toggle: Disable
+            disable-download-logging:
+                title: Disable logging downloads
+                toggle: Disable
+
+        buttons:
+            save: Save settings
+        help_texts:
+            description: >
+                Set up uploading services and preferences.
+            mime_types: >
+                Please configure your mapping here. Each mime type
+                regular expression will be handled by a specific
+                upload adapter and download template.
+            download_templates: >
+                Download templates are how uploads are shown on your forum,
+                eg like previews, buttons. Currently available:
+            resize: >
+                Choose whether you want to resize your images before
+                they get uploaded. You can choose a maximum width
+                and height, in pixels. The resizing process keeps the
+                aspect ratio of the images.
+            watermark: >
+                Choose whether images will have a watermark added during
+                upload. Watermarks are added to non-gifs based on your
+                preferences below.
+            disable-hotlink-protection: >
+                Hotlink protection prevents opening downloads from other sites.
+                Current method requires a csrf token and post id.
+            disable-download-logging: >
+                Disable logging every download made by users of your forum. Keeping it
+                enabled allows you to view the number of downloads and other metrics
+                in the nearby future.


### PR DESCRIPTION
Moves the traditional Flagrow upload button inside the "native toolbar", while maintaining all Flagrow upload functionality.  This only affects people with markdown installed, a fallback may be required for the minority that doesn't use the extension.  The previous image button is replaced with Upload's new file icon and should continue to work as intended.
The jumpy "Attach" button no longer pushes the composer toolbar to the right on hover, it's now done consistently with other buttons with tooltips.

**Things to consider**
The approach for replacing the button itself, i've had success with in local testing across varied installations. I suppose jquery could be used to locate the element instead, but other factors are involved to get a component's features all working correctly hijacking another extension.  This is my preferred method for now as it plays nice with Markdown, open to suggestions

i have considered moving the button to the far right of the toolbar and some style adjustments to make the end-user more aware, as of now functionality is blended almost too much so open for UI changes that could be made

will edit this with pictures to further demonstrate ~

**Locale**
the previous shorthand button label is now open for business as a tooltip inside the toolbar, so "Attach" isn't as descriptive as the other buttons.  I made some changes with it, but other locales will need adjusted

no unit testing on this stage