### PR TITLE
Ensure mimeTypes are what they appear to be

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     },
     "require": {
         "flarum/core": ">=0.1.0-beta.11 <0.1.0-beta.13",
-        "ramsey/uuid": "^3.5.2"
+        "ramsey/uuid": "^3.5.2",
+        "softcreatr/php-mime-detector": "^3.0"
     },
     "replace": {
         "flagrow/upload": "*"

--- a/src/Commands/UploadHandler.php
+++ b/src/Commands/UploadHandler.php
@@ -84,7 +84,7 @@ class UploadHandler
 
                 $uploadFileData = $this->mimeDetector->getFileType();
 
-                $mimeConfiguration = $this->getMimeConfiguration($uploadFileData->mime);
+                $mimeConfiguration = $this->getMimeConfiguration($uploadFileData['mime']);
                 $adapter = $this->getAdapter(Arr::get($mimeConfiguration, 'adapter'));
                 $template = $this->getTemplate(Arr::get($mimeConfiguration, 'template', 'file'));
 
@@ -96,14 +96,14 @@ class UploadHandler
                     throw new ValidationException(['upload' => 'Uploading files of this type is not allowed.']);
                 }
 
-                if (!$adapter->forMime($uploadFileData->mime)) {
-                    throw new ValidationException(['upload' => "Upload adapter does not support the provided mime type: {$upload->getClientMimeType()}."]);
+                if (!$adapter->forMime($uploadFileData['mime'])) {
+                    throw new ValidationException(['upload' => "Upload adapter does not support the provided mime type: {$uploadFileData['mime']}."]);
                 }
 
                 $file = $this->files->createFileFromUpload($upload, $command->actor);
 
                 $this->events->fire(
-                    new Events\File\WillBeUploaded($command->actor, $file, $upload)
+                    new Events\File\WillBeUploaded($command->actor, $file, $upload, $uploadFileData['mime'])
                 );
 
                 $response = $adapter->upload(
@@ -125,7 +125,7 @@ class UploadHandler
                 $file->actor_id = $command->actor->id;
 
                 $this->events->fire(
-                    new Events\File\WillBeSaved($command->actor, $file, $upload)
+                    new Events\File\WillBeSaved($command->actor, $file, $upload, $uploadFileData['mime'])
                 );
 
                 if ($file->isDirty() || !$file->exists) {
@@ -133,7 +133,7 @@ class UploadHandler
                 }
 
                 $this->events->fire(
-                    new Events\File\WasSaved($command->actor, $file, $upload)
+                    new Events\File\WasSaved($command->actor, $file, $upload, $uploadFileData['mime'])
                 );
             } catch (Exception $e) {
                 if (isset($upload)) {

--- a/src/Contracts/Processable.php
+++ b/src/Contracts/Processable.php
@@ -10,8 +10,9 @@ interface Processable
     /**
      * @param File         $file
      * @param UploadedFile $upload
+     * @param String $mime
      *
      * @return File
      */
-    public function process(File $file, UploadedFile $upload);
+    public function process(File $file, UploadedFile $upload, String $mime);
 }

--- a/src/Events/File/Event.php
+++ b/src/Events/File/Event.php
@@ -24,14 +24,21 @@ abstract class Event
     public $uploadedFile;
 
     /**
+     *
+     * @var String
+     */
+    public $mime;
+
+    /**
      * @param User         $actor
      * @param File         $file
      * @param UploadedFile $uploadedFile
      */
-    public function __construct(User $actor, File $file, UploadedFile $uploadedFile)
+    public function __construct(User $actor, File $file, UploadedFile $uploadedFile, String $mime)
     {
         $this->actor = $actor;
         $this->file = $file;
         $this->uploadedFile = $uploadedFile;
+        $this->mime = $mime;
     }
 }

--- a/src/Extenders/AddImageProcessor.php
+++ b/src/Extenders/AddImageProcessor.php
@@ -18,8 +18,8 @@ class AddImageProcessor implements ExtenderInterface
 
     public function processor(WillBeUploaded $event)
     {
-        if ($this->validateMime($event->file->type)) {
-            app(ImageProcessor::class)->process($event->file, $event->uploadedFile);
+        if ($this->validateMime($event->mime)) {
+            app(ImageProcessor::class)->process($event->file, $event->uploadedFile, $event->mime);
         }
     }
 

--- a/src/Processors/ImageProcessor.php
+++ b/src/Processors/ImageProcessor.php
@@ -28,9 +28,8 @@ class ImageProcessor implements Processable
      * @param File         $file
      * @param UploadedFile $upload
      */
-    public function process(File $file, UploadedFile $upload)
+    public function process(File $file, UploadedFile $upload, String $mimeType)
     {
-        $mimeType = $upload->getClientMimeType();
         if ($mimeType == 'image/jpeg' || $mimeType == 'image/png') {
             $image = (new ImageManager())->make($upload->getRealPath());
 
@@ -46,7 +45,7 @@ class ImageProcessor implements Processable
 
             @file_put_contents(
                 $upload->getRealPath(),
-                $image->encode($upload->getClientMimeType())
+                $image->encode($mimeType)
             );
         }
     }


### PR DESCRIPTION
Uses 'magic byte' detection of the mimetype, rather than using the supplied mime from the client