### PR TITLE
Apply height limit when resizing and image

### DIFF
--- a/js/src/admin/components/UploadPage.js
+++ b/js/src/admin/components/UploadPage.js
@@ -18,7 +18,7 @@ export default class UploadPage extends Component {
         // the fields we need to watch and to save
         this.fields = [
             // image
-            'resizeMaxWidth',
+            'resizeMaxSize',
             'cdnUrl',
             'maxFileSize',
             // watermark
@@ -197,11 +197,11 @@ export default class UploadPage extends Component {
                                 children: app.translator.trans('fof-upload.admin.labels.resize.toggle'),
                                 onchange: this.values.mustResize,
                             }),
-                            m('label', app.translator.trans('fof-upload.admin.labels.resize.max_width')),
+                            m('label', app.translator.trans('fof-upload.admin.labels.resize.max_size')),
                             m('input', {
                                 className: 'FormControl',
-                                value: this.values.resizeMaxWidth() || 100,
-                                oninput: m.withAttr('value', this.values.resizeMaxWidth),
+                                value: this.values.resizeMaxSize() || 100,
+                                oninput: m.withAttr('value', this.values.resizeMaxSize),
                                 disabled: !this.values.mustResize(),
                             }),
                         ]),

--- a/migrations/2020_06_18_08_rename_maxwidth_setting.php
+++ b/migrations/2020_06_18_08_rename_maxwidth_setting.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Schema\Builder;
+
+return [
+    'up' => function (Builder $schema) {
+        $fromKey = 'fof-upload.resizeMaxWidth';
+        $toKey = 'fof-upload.resizeMaxSize';
+
+        $settings = app(SettingsRepositoryInterface::class);
+        $value = $settings->get($fromKey);
+        if (!is_null($value)) {
+            $settings->set($toKey, $value);
+            $settings->delete($fromKey);
+        }
+    },
+    'down' => function (Builder $schema) {
+        $fromKey = 'fof-upload.resizeMaxSize';
+        $toKey = 'fof-upload.resizeMaxWidth';
+
+        $settings = app(SettingsRepositoryInterface::class);
+        $value = $settings->get($fromKey);
+        if (!is_null($value)) {
+            $settings->set($toKey, $value);
+            $settings->delete($fromKey);
+        }
+    },
+];

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -46,7 +46,7 @@ fof-upload:
         mime_types: 'Configure your mime type, upload adapter mapping'
         title: General preferences
       resize:
-        max_width: Maximum image width
+        max_size: Maximum image size
         title: Image resize
         toggle: Resize images
       watermark:

--- a/src/Helpers/Settings.php
+++ b/src/Helpers/Settings.php
@@ -12,7 +12,7 @@ use Qiniu\Http\Client as QiniuClient;
 class Settings
 {
     const DEFAULT_MAX_FILE_SIZE = 2048;
-    const DEFAULT_MAX_IMAGE_WIDTH = 100;
+    const DEFAULT_MAX_IMAGE_SIZE = 100;
 
     /**
      * The templates used to render files.

--- a/src/Processors/ImageProcessor.php
+++ b/src/Processors/ImageProcessor.php
@@ -61,9 +61,10 @@ class ImageProcessor implements Processable
      */
     protected function resize(Image $manager)
     {
+        $maxSize = $this->settings->get('resizeMaxWidth', Settings::DEFAULT_MAX_IMAGE_WIDTH);
         $manager->resize(
-            $this->settings->get('resizeMaxWidth', Settings::DEFAULT_MAX_IMAGE_WIDTH),
-            null,
+            $maxSize,
+            $maxSize,
             function ($constraint) {
                 $constraint->aspectRatio();
                 $constraint->upsize();

--- a/src/Processors/ImageProcessor.php
+++ b/src/Processors/ImageProcessor.php
@@ -61,7 +61,7 @@ class ImageProcessor implements Processable
      */
     protected function resize(Image $manager)
     {
-        $maxSize = $this->settings->get('resizeMaxWidth', Settings::DEFAULT_MAX_IMAGE_WIDTH);
+        $maxSize = $this->settings->get('resizeMaxSize', Settings::DEFAULT_MAX_IMAGE_SIZE);
         $manager->resize(
             $maxSize,
             $maxSize,


### PR DESCRIPTION
This pull request changes the resize operation to apply to both dimensions.

The first commit updates the `resize()` method as discussed in #218. The second renames the setting from `resizeMaxWidth` to `resizeMaxSize`.