### PR TITLE
Add client file extension whitelist feature

### DIFF
--- a/js/src/admin/components/UploadPage.js
+++ b/js/src/admin/components/UploadPage.js
@@ -21,6 +21,7 @@ export default class UploadPage extends Component {
             'resizeMaxWidth',
             'cdnUrl',
             'maxFileSize',
+            'whitelistedClientExtensions',
             // watermark
             'watermark',
             'watermarkPosition',
@@ -203,6 +204,15 @@ export default class UploadPage extends Component {
                                 value: this.values.resizeMaxWidth() || 100,
                                 oninput: m.withAttr('value', this.values.resizeMaxWidth),
                                 disabled: !this.values.mustResize(),
+                            }),
+                        ]),
+                        m('fieldset', [
+                            m('legend', app.translator.trans('fof-upload.admin.labels.client_extension.title')),
+                            m('.helpText', app.translator.trans('fof-upload.admin.help_texts.client_extension')),
+                            m('input', {
+                                className: 'FormControl',
+                                value: this.values.whitelistedClientExtensions() || '',
+                                oninput: m.withAttr('value', this.values.whitelistedClientExtensions),
                             }),
                         ]),
                         m('fieldset', [

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -15,6 +15,10 @@ fof-upload:
         Please configure your mapping here. Each mime type regular expression will be handled by a specific upload adapter and download template.
       resize: |
         Choose whether you want to resize your images before they get uploaded. You can choose a maximum width and height, in pixels. The resizing process keeps the aspect ratio of the images.
+      client_extension: |
+        By default Upload will choose a safe file extension based on the MIME type.
+        For some file types based around ZIP or binary data this can result in generic extensions being used instead of the expected one.
+        Here you can enter a comma-separated list of file extensions that will be kept verbatim.
       watermark: |
         Choose whether images will have a watermark added during upload. Watermarks are added to non-gifs based on your preferences below.
     labels:
@@ -49,6 +53,8 @@ fof-upload:
         max_width: Maximum image width
         title: Image resize
         toggle: Resize images
+      client_extension:
+        title: User-provided file extensions
       watermark:
         file: Upload your watermark image
         position: Watermark position


### PR DESCRIPTION
Fixes #224 
Fixes #221 
Related #9

I have pondered a few solutions for this issue and I don't think we can make a generic solution that works out of the box for everyone.

So this solution introduces a whitelist for files we won't attempt to rename.

I believe it also fixes a security issue where you could get the original client extension be used for files for which we couldn't guess the extension, which kind of defeats the whole purpose.

Now the extension defaults to `bin` if no other extension can be determined.

The client-provided file extension is only used if it's in the whitelist.

This solution should even cover the case of those who wanted to whitelist PHP files (we've had this request in the past). It's the responsibility of the forum owner to check the file extensions they whitelist won't cause issues with the adapter.

Question for reviewers: should I add the ability to whitelist everything? For example by inputting `*` in the field. This would be a very bad idea with a local adapter, but for other adapters it could make sense.