### PR TITLE
Interfaces for templates. Allow non-bbcode templates. Add URL template

### DIFF
--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -67,6 +67,9 @@ fof-upload:
         Shows the complete image in-line. No download functionality, no statistics are gathered and hotlink protection is ignored.
       image_description: |
         Shows a thumbnail of the image and proxies download through php. Allowing statistics to be gathered and hotlink protection.
+      just-url: Just URL
+      just-url_description: |
+        Inserts just the URL. Rendering can be handled by other extensions with auto-link ability. No download functionality, no statistics are gathered and hotlink protection is ignored.
     upload_methods:
       aws-s3: Amazon S3
       imgur: Imgur

--- a/src/Contracts/Template.php
+++ b/src/Contracts/Template.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace FoF\Upload\Contracts;
+
+use FoF\Upload\File;
+
+/**
+ * The base interface for a file template
+ */
+interface Template
+{
+    /**
+     * The unique tag for this template.
+     *
+     * @return string
+     */
+    public function tag(): string;
+
+    /**
+     * The human readable name of the template.
+     *
+     * @return string
+     */
+    public function name(): string;
+
+    /**
+     * A clarification of how this template works.
+     *
+     * @return string
+     */
+    public function description(): string;
+
+    /**
+     * Generates a preview bbcode string.
+     *
+     * @param File $file
+     *
+     * @return string
+     */
+    public function preview(File $file): string;
+}

--- a/src/Contracts/TextFormatterTemplate.php
+++ b/src/Contracts/TextFormatterTemplate.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace FoF\Upload\Contracts;
+
+/**
+ * An additional interface for templates that need to be registered in TextFormatter as a bbcode
+ */
+interface TextFormatterTemplate
+{
+    /**
+     * The bbcode definition.
+     *
+     * @return string
+     */
+    public function bbcode(): string;
+
+    /**
+     * The xsl template to use with this tag.
+     *
+     * @return string
+     */
+    public function template(): string;
+}

--- a/src/Extenders/AddPostDownloadTags.php
+++ b/src/Extenders/AddPostDownloadTags.php
@@ -2,8 +2,8 @@
 
 namespace FoF\Upload\Extenders;
 
+use FoF\Upload\Contracts\TextFormatterTemplate;
 use FoF\Upload\Helpers\Settings;
-use FoF\Upload\Templates\AbstractTemplate;
 use Flarum\Extend\Formatter;
 use Flarum\Extension\Extension;
 use Illuminate\Contracts\Container\Container;
@@ -17,14 +17,21 @@ class AddPostDownloadTags extends Formatter
     {
         $this->configure(function (Configurator $configurator) use ($container) {
             foreach ($container->make(Settings::class)->getRenderTemplates() as $name => $template) {
-                $this->createTag($configurator, $name, $template);
+                if ($template instanceof TextFormatterTemplate) {
+                    $this->createTag($configurator, $name, $template);
+                }
             }
         });
 
         parent::extend($container, $extension);
     }
 
-    protected function createTag(Configurator $configurator, string $name, AbstractTemplate $template)
+    /**
+     * @param Configurator $configurator
+     * @param string $name
+     * @param TextFormatterTemplate $template
+     */
+    protected function createTag(Configurator $configurator, string $name, TextFormatterTemplate $template)
     {
         try {
             $configurator->BBCodes->addCustom(

--- a/src/File.php
+++ b/src/File.php
@@ -3,8 +3,8 @@
 namespace FoF\Upload;
 
 use Carbon\Carbon;
+use FoF\Upload\Contracts\Template;
 use FoF\Upload\Contracts\UploadAdapter;
-use FoF\Upload\Templates\AbstractTemplate;
 use Flarum\Database\AbstractModel;
 use Flarum\Discussion\Discussion;
 use Flarum\Post\Post;
@@ -83,9 +83,9 @@ class File extends AbstractModel
     }
 
     /**
-     * @param AbstractTemplate $template
+     * @param Template $template
      */
-    public function setTagAttribute(AbstractTemplate $template)
+    public function setTagAttribute(Template $template)
     {
         $this->attributes['tag'] = $template->tag();
     }

--- a/src/Helpers/Settings.php
+++ b/src/Helpers/Settings.php
@@ -3,7 +3,7 @@
 namespace FoF\Upload\Helpers;
 
 use Aws\S3\S3Client;
-use FoF\Upload\Templates\AbstractTemplate;
+use FoF\Upload\Contracts\Template;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
@@ -124,15 +124,15 @@ class Settings
     }
 
     /**
-     * @param AbstractTemplate $template
+     * @param Template $template
      */
-    public function addRenderTemplate(AbstractTemplate $template)
+    public function addRenderTemplate(Template $template)
     {
         $this->renderTemplates[$template->tag()] = $template;
     }
 
     /**
-     * @return array
+     * @return Template[]
      */
     public function getRenderTemplates()
     {
@@ -140,7 +140,7 @@ class Settings
     }
 
     /**
-     * @param array $templates
+     * @param Template[] $templates
      */
     public function setRenderTemplates(array $templates)
     {
@@ -148,7 +148,7 @@ class Settings
     }
 
     /**
-     * @return Collection|AbstractTemplate[]
+     * @return Collection|Template[]
      */
     public function getAvailableTemplates()
     {
@@ -156,7 +156,7 @@ class Settings
 
         /**
          * @var string
-         * @var AbstractTemplate $template
+         * @var Template $template
          */
         foreach ($this->renderTemplates as $tag => $template) {
             $collect[$tag] = [
@@ -171,7 +171,7 @@ class Settings
     /**
      * @param string $template
      *
-     * @return AbstractTemplate|null
+     * @return Template|null
      */
     public function getTemplate($template)
     {

--- a/src/Providers/DownloadProvider.php
+++ b/src/Providers/DownloadProvider.php
@@ -2,13 +2,14 @@
 
 namespace FoF\Upload\Providers;
 
+use Flarum\Foundation\AbstractServiceProvider;
 use FoF\Upload\Commands\DownloadHandler;
 use FoF\Upload\Downloader\DefaultDownloader;
 use FoF\Upload\Helpers\Settings;
 use FoF\Upload\Templates\FileTemplate;
 use FoF\Upload\Templates\ImagePreviewTemplate;
 use FoF\Upload\Templates\ImageTemplate;
-use Flarum\Foundation\AbstractServiceProvider;
+use FoF\Upload\Templates\JustUrlTemplate;
 
 class DownloadProvider extends AbstractServiceProvider
 {
@@ -26,5 +27,6 @@ class DownloadProvider extends AbstractServiceProvider
         $settings->addRenderTemplate($this->app->make(FileTemplate::class));
         $settings->addRenderTemplate($this->app->make(ImageTemplate::class));
         $settings->addRenderTemplate($this->app->make(ImagePreviewTemplate::class));
+        $settings->addRenderTemplate($this->app->make(JustUrlTemplate::class));
     }
 }

--- a/src/Templates/AbstractTemplate.php
+++ b/src/Templates/AbstractTemplate.php
@@ -2,43 +2,24 @@
 
 namespace FoF\Upload\Templates;
 
-use FoF\Upload\File;
+use FoF\Upload\Contracts\Template;
 use Illuminate\Contracts\View\Factory;
 
-abstract class AbstractTemplate
+abstract class AbstractTemplate implements Template
 {
     /**
      * @var string
      */
     protected $tag;
 
-    /**
-     * The human readable name of the template.
-     *
-     * @return string
-     */
-    abstract public function name();
-
-    /**
-     * A clarification of how this template works.
-     *
-     * @return string
-     */
-    abstract public function description();
-
-    /**
-     * The unique tag for this template.
-     *
-     * @return string
-     */
-    public function tag()
+    public function tag(): string
     {
         return $this->tag;
     }
 
     /**
      * @param string $view
-     * @param array  $arguments
+     * @param array $arguments
      *
      * @return string
      */
@@ -56,46 +37,5 @@ abstract class AbstractTemplate
     protected function trans($key, array $params = [])
     {
         return app('translator')->trans($key, $params);
-    }
-
-    /**
-     * The rendered template to use with this tag.
-     *
-     * @return string
-     */
-    abstract public function template();
-
-    /**
-     * The bbcode to be parsed.
-     *
-     * @return string
-     */
-    abstract public function bbcode();
-
-    /**
-     * Generates a preview bbcode string.
-     *
-     * @param File $file
-     *
-     * @return string
-     */
-    public function preview(File $file)
-    {
-        $bbcode = $this->bbcode();
-
-        return preg_replace_callback_array([
-            '/\](?<find>.*)\[/' => function ($m) use ($file) {
-                return str_replace($m['find'], $file->base_name, $m[0]);
-            },
-            '/size=(?<find>{.*?})/' => function ($m) use ($file) {
-                return str_replace($m['find'], $file->humanSize, $m[0]);
-            },
-            '/uuid=(?<find>{.*?})/' => function ($m) use ($file) {
-                return str_replace($m['find'], $file->uuid, $m[0]);
-            },
-            '/url=(?<find>{.*?})/' => function ($m) use ($file) {
-                return str_replace($m['find'], $file->url, $m[0]);
-            },
-        ], $bbcode);
     }
 }

--- a/src/Templates/AbstractTextFormatterTemplate.php
+++ b/src/Templates/AbstractTextFormatterTemplate.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace FoF\Upload\Templates;
+
+use FoF\Upload\Contracts\TextFormatterTemplate;
+use FoF\Upload\File;
+
+abstract class AbstractTextFormatterTemplate extends AbstractTemplate implements TextFormatterTemplate
+{
+    public function preview(File $file): string
+    {
+        $bbcode = $this->bbcode();
+
+        return preg_replace_callback_array([
+            '/\](?<find>.*)\[/' => function ($m) use ($file) {
+                return str_replace($m['find'], $file->base_name, $m[0]);
+            },
+            '/size=(?<find>{.*?})/' => function ($m) use ($file) {
+                return str_replace($m['find'], $file->humanSize, $m[0]);
+            },
+            '/uuid=(?<find>{.*?})/' => function ($m) use ($file) {
+                return str_replace($m['find'], $file->uuid, $m[0]);
+            },
+            '/url=(?<find>{.*?})/' => function ($m) use ($file) {
+                return str_replace($m['find'], $file->url, $m[0]);
+            },
+        ], $bbcode);
+    }
+}

--- a/src/Templates/FileTemplate.php
+++ b/src/Templates/FileTemplate.php
@@ -2,7 +2,7 @@
 
 namespace FoF\Upload\Templates;
 
-class FileTemplate extends AbstractTemplate
+class FileTemplate extends AbstractTextFormatterTemplate
 {
     /**
      * @var string
@@ -12,7 +12,7 @@ class FileTemplate extends AbstractTemplate
     /**
      * {@inheritdoc}
      */
-    public function name()
+    public function name(): string
     {
         return $this->trans('fof-upload.admin.templates.file');
     }
@@ -20,27 +20,23 @@ class FileTemplate extends AbstractTemplate
     /**
      * {@inheritdoc}
      */
-    public function description()
+    public function description(): string
     {
         return $this->trans('fof-upload.admin.templates.file_description');
     }
 
     /**
-     * The xsl template to use with this tag.
-     *
-     * @return string
+     * {@inheritdoc}
      */
-    public function template()
+    public function template(): string
     {
         return $this->getView('fof-upload.templates::file');
     }
 
     /**
-     * The bbcode to be parsed.
-     *
-     * @return string
+     * {@inheritdoc}
      */
-    public function bbcode()
+    public function bbcode(): string
     {
         return '[upl-file uuid={IDENTIFIER} size={SIMPLETEXT2}]{SIMPLETEXT1}[/upl-file]';
     }

--- a/src/Templates/ImagePreviewTemplate.php
+++ b/src/Templates/ImagePreviewTemplate.php
@@ -2,7 +2,7 @@
 
 namespace FoF\Upload\Templates;
 
-class ImagePreviewTemplate extends AbstractTemplate
+class ImagePreviewTemplate extends AbstractTextFormatterTemplate
 {
     /**
      * @var string
@@ -12,7 +12,7 @@ class ImagePreviewTemplate extends AbstractTemplate
     /**
      * {@inheritdoc}
      */
-    public function name()
+    public function name(): string
     {
         return $this->trans('fof-upload.admin.templates.image-preview');
     }
@@ -20,27 +20,23 @@ class ImagePreviewTemplate extends AbstractTemplate
     /**
      * {@inheritdoc}
      */
-    public function description()
+    public function description(): string
     {
         return $this->trans('fof-upload.admin.templates.image-preview_description');
     }
 
     /**
-     * The xsl template to use with this tag.
-     *
-     * @return string
+     * {@inheritdoc}
      */
-    public function template()
+    public function template(): string
     {
         return $this->getView('fof-upload.templates::image-preview');
     }
 
     /**
-     * The bbcode to be parsed.
-     *
-     * @return string
+     * {@inheritdoc}
      */
-    public function bbcode()
+    public function bbcode(): string
     {
         return '[upl-image-preview url={URL}]';
     }

--- a/src/Templates/ImageTemplate.php
+++ b/src/Templates/ImageTemplate.php
@@ -2,7 +2,7 @@
 
 namespace FoF\Upload\Templates;
 
-class ImageTemplate extends AbstractTemplate
+class ImageTemplate extends AbstractTextFormatterTemplate
 {
     /**
      * @var string
@@ -12,7 +12,7 @@ class ImageTemplate extends AbstractTemplate
     /**
      * {@inheritdoc}
      */
-    public function name()
+    public function name(): string
     {
         return $this->trans('fof-upload.admin.templates.image');
     }
@@ -20,27 +20,23 @@ class ImageTemplate extends AbstractTemplate
     /**
      * {@inheritdoc}
      */
-    public function description()
+    public function description(): string
     {
         return $this->trans('fof-upload.admin.templates.image_description');
     }
 
     /**
-     * The xsl template to use with this tag.
-     *
-     * @return string
+     * {@inheritdoc}
      */
-    public function template()
+    public function template(): string
     {
         return $this->getView('fof-upload.templates::image');
     }
 
     /**
-     * The bbcode to be parsed.
-     *
-     * @return string
+     * {@inheritdoc}
      */
-    public function bbcode()
+    public function bbcode(): string
     {
         return '[upl-image uuid={IDENTIFIER} size={SIMPLETEXT2} url={URL}]{SIMPLETEXT1}[/upl-image]';
     }

--- a/src/Templates/JustUrlTemplate.php
+++ b/src/Templates/JustUrlTemplate.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace FoF\Upload\Templates;
+
+use FoF\Upload\File;
+
+class JustUrlTemplate extends AbstractTemplate
+{
+    /**
+     * @var string
+     */
+    protected $tag = 'just-url';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function name(): string
+    {
+        return $this->trans('fof-upload.admin.templates.just-url');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function description(): string
+    {
+        return $this->trans('fof-upload.admin.templates.just-url_description');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function preview(File $file): string
+    {
+        return $file->url;
+    }
+}


### PR DESCRIPTION
Fixes #187

Our current implementation isn't really friendly with custom templates that don't rely on bbcode. You could register a fake bbcode that you're not actually using but it's not super pretty or obvious.

This PR introduces interfaces for custom templates, with a separate interface if you want Upload to register the bbcode.

The PR also adds a new "just-url" template which... just inserts the URL. That way the extension can be used with AutoImage, AutoVideo and probably other extensions out of the box without the need to write that super simple template.

Backward compatibility questions:

This was almost a backward-compatible change but unfortunately the use of the separate interface that `AbstractTemplate` doesn't implement means custom templates would lose their bbcode. We could work around that by keeping `AbstractTemplate` explicitly for backward support and make it implement both interfaces.

The use of the `string` return type on the interfaces is also a breaking change we could easily solve if we don't want it.

Do we know of anyone running custom templates on their forum? I'm thinking it's best to release this as a developer breaking change as very few forums probably use the features and it's a more future-proof syntax.