### PR TITLE
Fix wrong setting values

### DIFF
--- a/src/Helpers/Settings.php
+++ b/src/Helpers/Settings.php
@@ -56,7 +56,7 @@ class Settings
      */
     public function get($name, $default = null)
     {
-        return $this->{$name} ?: $default;
+        return isset($this->{$name}) ? $this->{$name} : $default;
     }
 
     /**


### PR DESCRIPTION
Modified line was returning `true` everytime when the `default` value is set to `true` and stored value is set to `false`. This makes impossible to disable a setting which's `default` value is `true`.

I've wanted to use the unused `__isset()` magic method.