### PR TITLE
Fix console error when uploading to a new discussion OP

### DIFF
--- a/js/src/forum/addUploadButton.js
+++ b/js/src/forum/addUploadButton.js
@@ -27,16 +27,21 @@ export default function () {
         this.uploader.on('success', (image) => {
             this.attrs.composer.editor.insertAtCursor(image + '\n');
 
-            // Scroll the preview into view
-            // preview() causes the composer to close on mobile, but we don't want that. We want only the scroll
-            // We work around that by temporarily patching the isFullScreen method
-            const originalIsFullScreen = app.composer.isFullScreen;
+            // We wrap this in a typeof check to prevent it running when a user
+            // is creating a new discussion. There's nothing to preview in a new
+            // discussion, so the `preview` function isn't defined.
+            if (typeof this.attrs.preview === 'function') {
+                // Scroll the preview into view
+                // preview() causes the composer to close on mobile, but we don't want that. We want only the scroll
+                // We work around that by temporarily patching the isFullScreen method
+                const originalIsFullScreen = app.composer.isFullScreen;
 
-            app.composer.isFullScreen = () => false;
+                app.composer.isFullScreen = () => false;
 
-            this.attrs.preview();
+                this.attrs.preview();
 
-            app.composer.isFullScreen = originalIsFullScreen;
+                app.composer.isFullScreen = originalIsFullScreen;
+            }
         });
 
         const dragAndDrop = new DragAndDrop((files) => this.uploader.upload(files), this.$().parents('.Composer')[0]);


### PR DESCRIPTION
At the moment, the ext attempts to preview the content after the upload succeeds, but this creates an error if attempted on a new discussion.

![image](https://user-images.githubusercontent.com/7406822/104103816-17a50a80-529c-11eb-887c-fd20e955779d.png)

By wrapping the `.preview()` code in a `typeof` check, we can ensure that the post is only previewed if supported.