### PR TITLE
Fix console error when cancelling upload dialog

### DIFF
--- a/js/src/forum/components/UploadButton.js
+++ b/js/src/forum/components/UploadButton.js
@@ -54,6 +54,13 @@ export default class UploadButton extends Component {
         // get the file from the input field
         const files = this.$('input').prop('files');
 
+        if (files.length === 0) {
+            // We've got no files to upload, so trying
+            // to begin an upload will show an error
+            // to the user.
+            return;
+        }
+
         this.attrs.uploader.upload(files);
     }
 }


### PR DESCRIPTION
Sometimes, if a file has been uploaded, and the dialog is opened again and cancelled, the ext attempts to upload an empty set of files.

This fails, and shows an error (see video below).

This PR ensures that uploads are only attempted if at least 1 file is selected.

https://user-images.githubusercontent.com/7406822/104103952-fc86ca80-529c-11eb-8ca7-6e3b98962254.mp4

