### PR TITLE
Remove invisible input hack in upload toolbar

### DIFF
--- a/js/src/forum/components/UploadButton.js
+++ b/js/src/forum/components/UploadButton.js
@@ -1,15 +1,15 @@
-import app from "flarum/app";
-import Component from "flarum/Component";
-import icon from "flarum/helpers/icon";
-import LoadingIndicator from "flarum/components/LoadingIndicator";
+import app from 'flarum/app';
+import Component from 'flarum/Component';
+import icon from 'flarum/helpers/icon';
+import LoadingIndicator from 'flarum/components/LoadingIndicator';
 
 export default class UploadButton extends Component {
     oninit(vnode) {
         super.oninit(vnode);
 
-        this.attrs.uploader.on("uploaded", () => {
+        this.attrs.uploader.on('uploaded', () => {
             // reset the button for a new upload
-            this.$("form")[0].reset();
+            this.$('form')[0].reset();
 
             // redraw to reflect uploader.loading in the DOM
             m.redraw();
@@ -18,26 +18,26 @@ export default class UploadButton extends Component {
 
     view() {
         const buttonText = this.attrs.uploader.uploading
-            ? app.translator.trans("fof-upload.forum.states.loading")
-            : app.translator.trans("fof-upload.forum.buttons.attach");
+            ? app.translator.trans('fof-upload.forum.states.loading')
+            : app.translator.trans('fof-upload.forum.buttons.attach');
 
         return m(
-            "button.Button.hasIcon.fof-upload-button.Button--icon",
+            'button.Button.hasIcon.fof-upload-button.Button--icon',
             {
-                className: this.attrs.uploader.uploading ? "uploading" : "",
+                className: this.attrs.uploader.uploading ? 'uploading' : '',
                 onclick: this.uploadButtonClicked.bind(this),
             },
             [
                 this.attrs.uploader.uploading
                     ? LoadingIndicator.component({
-                          size: "tiny",
-                          className: "LoadingIndicator--inline Button-icon",
+                          size: 'tiny',
+                          className: 'LoadingIndicator--inline Button-icon',
                       })
-                    : icon("fas fa-file-upload", { className: "Button-icon" }),
-                m("span.Button-label", buttonText),
-                m("form", [
-                    m("input", {
-                        type: "file",
+                    : icon('fas fa-file-upload', { className: 'Button-icon' }),
+                m('span.Button-label', buttonText),
+                m('form', [
+                    m('input', {
+                        type: 'file',
                         multiple: true,
                         onchange: this.process.bind(this),
                     }),
@@ -53,7 +53,7 @@ export default class UploadButton extends Component {
      */
     process(e) {
         // get the file from the input field
-        const files = this.$("input").prop("files");
+        const files = this.$('input').prop('files');
 
         this.attrs.uploader.upload(files);
     }
@@ -66,6 +66,6 @@ export default class UploadButton extends Component {
     uploadButtonClicked(e) {
         // Trigger click on hidden input element
         // (Opens file dialog)
-        this.$("input").click();
+        this.$('input').click();
     }
 }

--- a/js/src/forum/components/UploadButton.js
+++ b/js/src/forum/components/UploadButton.js
@@ -25,7 +25,7 @@ export default class UploadButton extends Component {
             "button.Button.hasIcon.fof-upload-button.Button--icon",
             {
                 className: this.attrs.uploader.uploading ? "uploading" : "",
-                onclick: (e) => this.uploadButtonClicked(e, this),
+                onclick: this.uploadButtonClicked.bind(this),
             },
             [
                 this.attrs.uploader.uploading
@@ -62,11 +62,10 @@ export default class UploadButton extends Component {
      * Event handler for upload button being clicked
      *
      * @param {PointerEvent} e
-     * @param that Pass-through of `this` from component
      */
-    uploadButtonClicked(e, that) {
+    uploadButtonClicked(e) {
         // Trigger click on hidden input element
         // (Opens file dialog)
-        that.$("input").click();
+        this.$("input").click();
     }
 }

--- a/js/src/forum/components/UploadButton.js
+++ b/js/src/forum/components/UploadButton.js
@@ -1,15 +1,15 @@
-import app from 'flarum/app';
-import Component from 'flarum/Component';
-import icon from 'flarum/helpers/icon';
-import LoadingIndicator from 'flarum/components/LoadingIndicator';
+import app from "flarum/app";
+import Component from "flarum/Component";
+import icon from "flarum/helpers/icon";
+import LoadingIndicator from "flarum/components/LoadingIndicator";
 
 export default class UploadButton extends Component {
     oninit(vnode) {
         super.oninit(vnode);
 
-        this.attrs.uploader.on('uploaded', () => {
+        this.attrs.uploader.on("uploaded", () => {
             // reset the button for a new upload
-            this.$('form')[0].reset();
+            this.$("form")[0].reset();
 
             // redraw to reflect uploader.loading in the DOM
             m.redraw();
@@ -18,25 +18,26 @@ export default class UploadButton extends Component {
 
     view() {
         const buttonText = this.attrs.uploader.uploading
-            ? app.translator.trans('fof-upload.forum.states.loading')
-            : app.translator.trans('fof-upload.forum.buttons.attach');
+            ? app.translator.trans("fof-upload.forum.states.loading")
+            : app.translator.trans("fof-upload.forum.buttons.attach");
 
         return m(
-            '.Button.hasIcon.fof-upload-button.Button--icon',
+            ".Button.hasIcon.fof-upload-button.Button--icon",
             {
-                className: this.attrs.uploader.uploading ? 'uploading' : '',
+                className: this.attrs.uploader.uploading ? "uploading" : "",
+                onclick: (e) => this.uploadButtonClicked(e, this),
             },
             [
                 this.attrs.uploader.uploading
                     ? LoadingIndicator.component({
-                          size: 'tiny',
-                          className: 'LoadingIndicator--inline Button-icon',
+                          size: "tiny",
+                          className: "LoadingIndicator--inline Button-icon",
                       })
-                    : icon('fas fa-file-upload', { className: 'Button-icon' }),
-                m('span.Button-label', buttonText),
-                m('form', [
-                    m('input', {
-                        type: 'file',
+                    : icon("fas fa-file-upload", { className: "Button-icon" }),
+                m("span.Button-label", buttonText),
+                m("form", [
+                    m("input", {
+                        type: "file",
                         multiple: true,
                         onchange: this.process.bind(this),
                     }),
@@ -52,8 +53,20 @@ export default class UploadButton extends Component {
      */
     process(e) {
         // get the file from the input field
-        const files = this.$('input').prop('files');
+        const files = this.$("input").prop("files");
 
         this.attrs.uploader.upload(files);
+    }
+
+    /**
+     * Event handler for upload button being clicked
+     *
+     * @param {PointerEvent} e
+     * @param that Pass-through of `this` from component
+     */
+    uploadButtonClicked(e, that) {
+        // Trigger click on hidden input element
+        // (Opens file dialog)
+        that.$("input").click();
     }
 }

--- a/js/src/forum/components/UploadButton.js
+++ b/js/src/forum/components/UploadButton.js
@@ -22,7 +22,7 @@ export default class UploadButton extends Component {
             : app.translator.trans("fof-upload.forum.buttons.attach");
 
         return m(
-            ".Button.hasIcon.fof-upload-button.Button--icon",
+            "button.Button.hasIcon.fof-upload-button.Button--icon",
             {
                 className: this.attrs.uploader.uploading ? "uploading" : "",
                 onclick: (e) => this.uploadButtonClicked(e, this),

--- a/resources/less/forum/upload.less
+++ b/resources/less/forum/upload.less
@@ -3,22 +3,15 @@
     position: relative;
 
     input {
-        position: absolute;
-        top: 0;
-        right: 0;
-        margin: 0;
-        padding: 0;
-        font-size: 20px;
-        cursor: pointer;
-        opacity: 0;
-        filter: alpha(opacity=0);
+        display: none;
     }
 
     .Button-label {
         display: none;
     }
 
-    &:hover, &.uploading {
+    &:hover,
+    &.uploading {
         // Cancel the effects of .Button--icon
         width: auto;
         padding: 8px 13px;


### PR DESCRIPTION
At the moment, there's an input element inside the toolbar button. This input is rendered, and layered just below the button itself. The entire file selection process is handled by the input, so any clicks on the button which are just outside the input element are ignored.

This PR prevents the input being rendered entirely, substituting `opacity: 0` with `display: none`. Then, we add an `onclick` handler to the toolbar button which triggers the input dialog to open.

After this, everything continues as normal.

---

This also removes the need for focus styling hacks: currently the focus is given to the input element, meaning that we can't use `:focus-visible` to provide keyboard-only focus styles to the button, instead having to use `:focus-within`, which also shows these focus styles when clicking the upload button with a mouse, which might be undesirable.