### PR TITLE
Afford keyboard navigators the same styling rights as mouse users

### DIFF
--- a/resources/less/forum/upload.less
+++ b/resources/less/forum/upload.less
@@ -11,6 +11,8 @@
     }
 
     &:hover,
+    &:focus,
+    &:active,
     &.uploading {
         // Cancel the effects of .Button--icon
         width: auto;


### PR DESCRIPTION
This PR allows keyboard users to see what the upload button does (shows the upload text on focus).

Previously, the text was only shown on hover and, because there was no tooltip, there was no way to see the function of the button.

https://user-images.githubusercontent.com/7406822/104962650-c8b05100-59d0-11eb-8e9e-19b212c28ec8.mp4

