### PR TITLE
Bytedance ImageX Adapter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,11 +39,13 @@
     },
     "suggest": {
         "league/flysystem-aws-s3-v3": "Uploads to AWS S3 using API version 3.",
-        "overtrue/flysystem-qiniu": "Uploads to QiNiu using API."
+        "overtrue/flysystem-qiniu": "Uploads to QiNiu using API.",
+        "exercisebook/flysystem-imagex": "Uploads to ImageX using API."
     },
     "require-dev": {
         "league/flysystem-aws-s3-v3": "^1.0",
-        "overtrue/flysystem-qiniu": "1.0.4"
+        "overtrue/flysystem-qiniu": "1.0.4",
+        "exercisebook/flysystem-imagex": "<1.0"
     },
     "extra": {
         "flarum-extension": {

--- a/js/src/admin/components/UploadPage.js
+++ b/js/src/admin/components/UploadPage.js
@@ -42,6 +42,12 @@ export default class UploadPage extends ExtensionPage {
             'qiniuKey',
             'qiniuSecret',
             'qiniuBucket',
+            // ImageX
+            'imagexRegion',
+            'imagexAccessKey',
+            'imagexSecretKey',
+            'imagexServiceId',
+            'imagexDomain',
         ];
 
         // the checkboxes we need to watch and to save.
@@ -404,6 +410,44 @@ export default class UploadPage extends ExtensionPage {
                             oninput: withAttr('value', this.values.awsS3ACL),
                         }),
                         m('.helpText', app.translator.trans('fof-upload.admin.help_texts.s3_acl')),
+                    ]),
+                ])
+            );
+        }
+
+        console.log(this.uploadMethodOptions);
+
+        if (this.uploadMethodOptions['imagex'] !== undefined) {
+            items.add(
+                'imagex',
+                m('.imagex', [
+                    m('fieldset', [
+                        m('legend', app.translator.trans('fof-upload.admin.labels.imagex.title')),
+                        m('label', app.translator.trans('fof-upload.admin.labels.imagex.region')),
+                        m('input.FormControl', {
+                            value: this.values.imagexRegion() || '',
+                            oninput: withAttr('value', this.values.imagexRegion),
+                        }),
+                        m('label', app.translator.trans('fof-upload.admin.labels.imagex.accessKey')),
+                        m('input.FormControl', {
+                            value: this.values.imagexAccessKey() || '',
+                            oninput: withAttr('value', this.values.imagexAccessKey),
+                        }),
+                        m('label', app.translator.trans('fof-upload.admin.labels.imagex.secretKey')),
+                        m('input.FormControl', {
+                            value: this.values.imagexSecretKey() || '',
+                            oninput: withAttr('value', this.values.imagexSecretKey),
+                        }),
+                        m('label', {}, app.translator.trans('fof-upload.admin.labels.imagex.serviceId')),
+                        m('input.FormControl', {
+                            value: this.values.imagexServiceId() || '',
+                            oninput: withAttr('value', this.values.imagexServiceId),
+                        }),
+                        m('label', app.translator.trans('fof-upload.admin.labels.imagex.domain')),
+                        m('input.FormControl', {
+                            value: this.values.imagexDomain() || '',
+                            oninput: withAttr('value', this.values.imagexDomain),
+                        }),
                     ]),
                 ])
             );

--- a/js/src/admin/components/UploadPage.js
+++ b/js/src/admin/components/UploadPage.js
@@ -48,6 +48,7 @@ export default class UploadPage extends ExtensionPage {
             'imagexSecretKey',
             'imagexServiceId',
             'imagexDomain',
+            'imagexTemplate',
         ];
 
         // the checkboxes we need to watch and to save.
@@ -447,6 +448,11 @@ export default class UploadPage extends ExtensionPage {
                         m('input.FormControl', {
                             value: this.values.imagexDomain() || '',
                             oninput: withAttr('value', this.values.imagexDomain),
+                        }),
+                        m('label', app.translator.trans('fof-upload.admin.labels.imagex.template')),
+                        m('input.FormControl', {
+                            value: this.values.imagexTemplate() || '',
+                            oninput: withAttr('value', this.values.imagexTemplate),
                         }),
                     ]),
                 ])

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -57,6 +57,14 @@ fof-upload:
         secret: Secret
         bucket: Bucket
       preferences:
+      imagex:
+        title: ImageX storage settings
+        region: Region
+        accessKey: Access key
+        secretKey: Secret key
+        serviceId: Service id
+        domain: Binded domain
+      preferences:
         max_file_size: Maximum file size (in kilobytes)
         mime_types: 'Configure your mime type, upload adapter mapping'
         title: General preferences
@@ -102,6 +110,7 @@ fof-upload:
       local: Local
       ovh-svfs: OVH SVFS
       qiniu: QiNiu
+      imagex: ImageX
   forum:
     media_manager: Media manager
 

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -64,6 +64,7 @@ fof-upload:
         secretKey: Secret key
         serviceId: Service id
         domain: Binded domain
+        template: Template
       preferences:
         max_file_size: Maximum file size (in kilobytes)
         mime_types: 'Configure your mime type, upload adapter mapping'

--- a/src/Adapters/ImageX.php
+++ b/src/Adapters/ImageX.php
@@ -1,0 +1,61 @@
+<?php
+
+
+namespace FoF\Upload\Adapters;
+
+
+use ExerciseBook\Flysystem\ImageX\ImageXAdapter;
+use ExerciseBook\Flysystem\ImageX\ImageXConfig;
+use Flarum\Foundation\ValidationException;
+use Flarum\Settings\SettingsRepositoryInterface;
+use FoF\Upload\Contracts\UploadAdapter;
+use FoF\Upload\File;
+use League\Flysystem\AdapterInterface;
+use League\Flysystem\Config;
+
+class ImageX extends Flysystem implements UploadAdapter
+{
+    /**
+     * @var string Resources uri Prefix
+     */
+    private $uriPrefix;
+
+    /**
+     * @var ImageXConfig ImageX Client Settings
+     */
+    private $config;
+
+    /**
+     * @var array ImageX Client Settings
+     */
+    private $arrConfig;
+
+    public function __construct($config)
+    {
+        parent::__construct(new ImageXAdapter($config));
+
+        // Save config
+        $this->config = new ImageXConfig();
+
+        $this->config->region = $config["region"];
+        $this->config->accessKey = $config["access_key"];
+        $this->config->secretKey = $config["secret_key"];
+        $this->config->serviceId = $config["service_id"];
+        $this->config->domain = $config["domain"];
+
+        $this->arrConfig = $config;
+        $this->uriPrefix = $this->adapter->imageXBuildUriPrefix();
+    }
+
+    protected function getConfig()
+    {
+        return new Config($this->arrConfig);
+    }
+
+    protected function generateUrl(File $file)
+    {
+        $path = $file->getAttribute('path');
+        $url = '//' . $this->config->domain . '/' . $this->uriPrefix . '/' . $path;
+        $file->url = $url;
+    }
+}

--- a/src/Adapters/ImageX.php
+++ b/src/Adapters/ImageX.php
@@ -6,11 +6,9 @@ namespace FoF\Upload\Adapters;
 
 use ExerciseBook\Flysystem\ImageX\ImageXAdapter;
 use ExerciseBook\Flysystem\ImageX\ImageXConfig;
-use Flarum\Foundation\ValidationException;
-use Flarum\Settings\SettingsRepositoryInterface;
 use FoF\Upload\Contracts\UploadAdapter;
 use FoF\Upload\File;
-use League\Flysystem\AdapterInterface;
+use Illuminate\Support\Str;
 use League\Flysystem\Config;
 
 class ImageX extends Flysystem implements UploadAdapter
@@ -54,8 +52,15 @@ class ImageX extends Flysystem implements UploadAdapter
 
     protected function generateUrl(File $file)
     {
+        $type = mb_strtolower($file->type);
         $path = $file->getAttribute('path');
-        $url = '//' . $this->config->domain . '/' . $this->uriPrefix . '/' . $path;
+        $template = $this->arrConfig["template"];
+
+        if (Str::startsWith($type, "image/") && $template) {
+            $url = '//' . $this->config->domain . '/' . $this->uriPrefix . '/' . $path . '~' . $template . '.image';
+        } else {
+            $url = '//' . $this->config->domain . '/' . $this->uriPrefix . '/' . $path;
+        }
         $file->url = $url;
     }
 }

--- a/src/Adapters/ImageX.php
+++ b/src/Adapters/ImageX.php
@@ -1,8 +1,16 @@
 <?php
 
+/*
+ * This file is part of fof/upload.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ * Copyright (c) Flagrow.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 namespace FoF\Upload\Adapters;
-
 
 use ExerciseBook\Flysystem\ImageX\ImageXAdapter;
 use ExerciseBook\Flysystem\ImageX\ImageXConfig;
@@ -35,11 +43,11 @@ class ImageX extends Flysystem implements UploadAdapter
         // Save config
         $this->config = new ImageXConfig();
 
-        $this->config->region = $config["region"];
-        $this->config->accessKey = $config["access_key"];
-        $this->config->secretKey = $config["secret_key"];
-        $this->config->serviceId = $config["service_id"];
-        $this->config->domain = $config["domain"];
+        $this->config->region = $config['region'];
+        $this->config->accessKey = $config['access_key'];
+        $this->config->secretKey = $config['secret_key'];
+        $this->config->serviceId = $config['service_id'];
+        $this->config->domain = $config['domain'];
 
         $this->arrConfig = $config;
         $this->uriPrefix = $this->adapter->imageXBuildUriPrefix();
@@ -54,12 +62,12 @@ class ImageX extends Flysystem implements UploadAdapter
     {
         $type = mb_strtolower($file->type);
         $path = $file->getAttribute('path');
-        $template = $this->arrConfig["template"];
+        $template = $this->arrConfig['template'];
 
-        if (Str::startsWith($type, "image/") && $template) {
-            $url = '//' . $this->config->domain . '/' . $this->uriPrefix . '/' . $path . '~' . $template . '.image';
+        if (Str::startsWith($type, 'image/') && $template) {
+            $url = '//'.$this->config->domain.'/'.$this->uriPrefix.'/'.$path.'~'.$template.'.image';
         } else {
-            $url = '//' . $this->config->domain . '/' . $this->uriPrefix . '/' . $path;
+            $url = '//'.$this->config->domain.'/'.$this->uriPrefix.'/'.$path;
         }
         $file->url = $url;
     }

--- a/src/Adapters/Manager.php
+++ b/src/Adapters/Manager.php
@@ -3,10 +3,10 @@
 /*
  * This file is part of fof/upload.
  *
- * Copyright (c) 2020 - 2021 FriendsOfFlarum.
- * Copyright (c) 2016 - 2019 Flagrow
+ * Copyright (c) FriendsOfFlarum.
+ * Copyright (c) Flagrow.
  *
- * For the full copyright and license information, please view the LICENSE.md
+ * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
@@ -198,13 +198,13 @@ class Manager
         }
 
         $config = [
-                "region" => $this->settings->get('fof-upload.imagexRegion'),
-                "access_key" => $this->settings->get('fof-upload.imagexAccessKey'),
-                "secret_key" => $this->settings->get('fof-upload.imagexSecretKey'),
-                "service_id" => $this->settings->get('fof-upload.imagexServiceId'),
-                "domain" => $this->settings->get('fof-upload.imagexDomain'),
-                "template" => $this->settings->get('fof-upload.imagexTemplate'),
-            ];
+            'region'     => $this->settings->get('fof-upload.imagexRegion'),
+            'access_key' => $this->settings->get('fof-upload.imagexAccessKey'),
+            'secret_key' => $this->settings->get('fof-upload.imagexSecretKey'),
+            'service_id' => $this->settings->get('fof-upload.imagexServiceId'),
+            'domain'     => $this->settings->get('fof-upload.imagexDomain'),
+            'template'   => $this->settings->get('fof-upload.imagexTemplate'),
+        ];
 
         return new Adapters\ImageX($config);
     }

--- a/src/Adapters/Manager.php
+++ b/src/Adapters/Manager.php
@@ -183,7 +183,7 @@ class Manager
     /**
      * @param Util $util
      *
-     * @return Adapters\Local
+     * @return ImageX
      */
     protected function imagex(Util $util)
     {
@@ -203,6 +203,7 @@ class Manager
                 "secret_key" => $this->settings->get('fof-upload.imagexSecretKey'),
                 "service_id" => $this->settings->get('fof-upload.imagexServiceId'),
                 "domain" => $this->settings->get('fof-upload.imagexDomain'),
+                "template" => $this->settings->get('fof-upload.imagexTemplate'),
             ];
 
         return new Adapters\ImageX($config);

--- a/src/Adapters/Manager.php
+++ b/src/Adapters/Manager.php
@@ -13,6 +13,7 @@
 namespace FoF\Upload\Adapters;
 
 use Aws\S3\S3Client;
+use ExerciseBook\Flysystem\ImageX\ImageXAdapter as ImageXClient;
 use Flarum\Foundation\Paths;
 use Flarum\Foundation\ValidationException;
 use Flarum\Settings\SettingsRepositoryInterface;
@@ -64,6 +65,8 @@ class Manager
             'imgur'  => true,
             'qiniu'  => class_exists(QiniuClient::class),
             'local'  => true,
+
+            'imagex'  => class_exists(ImageXClient::class),
         ]);
 
         $this->events->dispatch(new Collecting($adapters));
@@ -175,5 +178,33 @@ class Manager
         );
 
         return new Adapters\Qiniu($client);
+    }
+
+    /**
+     * @param Util $util
+     *
+     * @return Adapters\Local
+     */
+    protected function imagex(Util $util)
+    {
+        if (
+            !$this->settings->get('fof-upload.imagexRegion') ||
+            !$this->settings->get('fof-upload.imagexAccessKey') ||
+            !$this->settings->get('fof-upload.imagexSecretKey') ||
+            !$this->settings->get('fof-upload.imagexServiceId') ||
+            !$this->settings->get('fof-upload.imagexDomain')
+        ) {
+            return null;
+        }
+
+        $config = [
+                "region" => $this->settings->get('fof-upload.imagexRegion'),
+                "access_key" => $this->settings->get('fof-upload.imagexAccessKey'),
+                "secret_key" => $this->settings->get('fof-upload.imagexSecretKey'),
+                "service_id" => $this->settings->get('fof-upload.imagexServiceId'),
+                "domain" => $this->settings->get('fof-upload.imagexDomain'),
+            ];
+
+        return new Adapters\ImageX($config);
     }
 }


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**

To add the [ImageX](https://www.volcengine.com/product/imagex) adapter to fof-upload.

**Reviewers should focus on:**
- [ ] Is `composer.json` correct? Maybe I forget to add the suggested package into this file.
- [ ] Is my code works well without installing [exercisebook/flysystem-imagex](https://packagist.org/packages/exercisebook/flysystem-imagex) ? If well, it can not see ImageX options on admin panel.

**Screenshot**
Admin
![Admin](https://user-images.githubusercontent.com/6327311/115955196-b988f400-a527-11eb-9912-a81bb2044926.png)

Upload image file without setting template.
We can see that there is no template ID at the end of the URL.
![Upload image file without setting template.](https://user-images.githubusercontent.com/6327311/115955223-e0dfc100-a527-11eb-98b0-9e0b3acb4e0a.png)

Upload image file with template setting.
We can see that there is a template ID at the end of the URL.
![Upload image file with template setting.](https://user-images.githubusercontent.com/6327311/115955250-079df780-a528-11eb-94b6-91aec244b2f1.png)

Upload a non-image file but with template setting on.
![Upload a non-image file but with template setting on.](https://user-images.githubusercontent.com/6327311/115955282-2f8d5b00-a528-11eb-9511-2f0c12068122.png)

```php
    protected function generateUrl(File $file)
    {
        $type = mb_strtolower($file->type);
        $path = $file->getAttribute('path');
        $template = $this->arrConfig["template"];

        if (Str::startsWith($type, "image/") && $template) {  // Check is image file or not.
            $url = '//' . $this->config->domain . '/' . $this->uriPrefix . '/' . $path . '~' . $template . '.image';
        } else {
            $url = '//' . $this->config->domain . '/' . $this->uriPrefix . '/' . $path;
        }
        $file->url = $url;
    }
```

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

None
