### PR TITLE
Insert upload code without escaping

### DIFF
--- a/js/src/forum/addUploadButton.js
+++ b/js/src/forum/addUploadButton.js
@@ -43,7 +43,7 @@ export default function () {
         this.uploader.on('success', ({ file, addBBcode }) => {
             if (!addBBcode) return;
 
-            this.attrs.composer.editor.insertAtCursor(file.bbcode() + '\n');
+            this.attrs.composer.editor.insertAtCursor(file.bbcode() + '\n', false);
 
             // We wrap this in a typeof check to prevent it running when a user
             // is creating a new discussion. There's nothing to preview in a new

--- a/js/src/forum/components/FileManagerModal.js
+++ b/js/src/forum/components/FileManagerModal.js
@@ -154,7 +154,7 @@ export default class FileManagerModal extends Modal {
         this.selectedFiles.map((fileId) => {
             const file = app.store.getById('files', fileId);
 
-            app.composer.editor.insertAtCursor(file.bbcode() + '\n');
+            app.composer.editor.insertAtCursor(file.bbcode() + '\n', false);
         });
     }
 }


### PR DESCRIPTION
This allows the rich text extension to preview links when the markdown driver is selected.