### PR TITLE
MIME inspection tool

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -25,6 +25,7 @@ return [
         ->post('/fof/upload', 'fof-upload.upload', Api\Controllers\UploadController::class)
         ->post('/fof/watermark', 'fof-upload.watermark', Api\Controllers\WatermarkUploadController::class)
         ->get('/fof/download/{uuid}/{post}/{csrf}', 'fof-upload.download', Api\Controllers\DownloadController::class)
+        ->post('/fof/upload/inspect-mime', 'fof-upload.inspect-mime', Api\Controllers\InspectMimeController::class)
         ->patch('/fof/upload/hide', 'fof-upload.hide', Api\Controllers\HideUploadFromMediaManagerController::class),
 
     (new Extend\Csrf())->exemptRoute('fof-upload.download'),

--- a/js/src/admin/components/InspectMimeModal.js
+++ b/js/src/admin/components/InspectMimeModal.js
@@ -1,0 +1,111 @@
+import app from 'flarum/admin/app';
+import Modal from 'flarum/common/components/Modal';
+import LoadingIndicator from 'flarum/common/components/LoadingIndicator';
+
+export default class InspectMimeModal extends Modal {
+  oninit(vnode) {
+    super.oninit(vnode);
+
+    this.uploading = false;
+    this.inspection = {};
+  }
+
+  className() {
+    return 'Modal--small fof-upload-inspect-mime-modal';
+  }
+
+  title() {
+    return app.translator.trans('fof-upload.admin.inspect-mime.title');
+  }
+
+  content() {
+    return (
+      <div className="Modal-body">
+        <p>
+          {app.translator.trans('fof-upload.admin.inspect-mime.description', {
+            a: <a href="https://github.com/SoftCreatR/php-mime-detector"></a>,
+          })}
+        </p>
+        <p>{app.translator.trans('fof-upload.admin.inspect-mime.select')}</p>
+        <div>
+          <input type="file" onchange={this.onupload.bind(this)} disabled={this.uploading} />
+          {this.uploading ? LoadingIndicator.component() : null}
+        </div>
+        <dl>
+          <dt>{app.translator.trans('fof-upload.admin.inspect-mime.laravel-validation')}</dt>
+          <dd>
+            {typeof this.inspection.laravel_validation === 'undefined' ? (
+              <em>{app.translator.trans('fof-upload.admin.inspect-mime.no-file-selected')}</em>
+            ) : this.inspection.laravel_validation ? (
+              app.translator.trans('fof-upload.admin.inspect-mime.validation-passed')
+            ) : (
+              app.translator.trans('fof-upload.admin.inspect-mime.validation-failed', {
+                error: this.inspection.laravel_validation_error || '?',
+              })
+            )}
+          </dd>
+        </dl>
+        <dl>
+          <dt>{app.translator.trans('fof-upload.admin.inspect-mime.mime-detector')}</dt>
+          <dd>
+            {this.inspection.mime_detector ? (
+              <code>{this.inspection.mime_detector}</code>
+            ) : (
+              <em>{app.translator.trans('fof-upload.admin.inspect-mime.not-available')}</em>
+            )}
+          </dd>
+        </dl>
+        <dl>
+          <dt>{app.translator.trans('fof-upload.admin.inspect-mime.mime-fileinfo')}</dt>
+          <dd>
+            {this.inspection.php_mime ? (
+              <code>{this.inspection.php_mime}</code>
+            ) : (
+              <em>{app.translator.trans('fof-upload.admin.inspect-mime.not-available')}</em>
+            )}
+          </dd>
+        </dl>
+        <dl>
+          <dt>{app.translator.trans('fof-upload.admin.inspect-mime.guessed-extension')}</dt>
+          <dd>
+            {this.inspection.guessed_extension ? (
+              <code>{this.inspection.guessed_extension}</code>
+            ) : (
+              <em>{app.translator.trans('fof-upload.admin.inspect-mime.not-available')}</em>
+            )}
+          </dd>
+        </dl>
+      </div>
+    );
+  }
+
+  onupload(event) {
+    const body = new FormData();
+
+    for (let i = 0; i < event.target.files.length; i++) {
+      body.append('files[]', event.target.files[i]);
+    }
+
+    this.uploading = true;
+
+    return app
+      .request({
+        method: 'POST',
+        url: app.forum.attribute('apiUrl') + '/fof/upload/inspect-mime',
+        serialize: (raw) => raw,
+        body,
+      })
+      .then((result) => {
+        this.uploading = false;
+        this.inspection = result;
+        m.redraw();
+      })
+      .catch((error) => {
+        this.uploading = false;
+        this.inspection = {};
+        m.redraw();
+
+        throw error;
+      });
+  }
+}

--- a/js/src/admin/components/UploadPage.js
+++ b/js/src/admin/components/UploadPage.js
@@ -9,6 +9,7 @@ import withAttr from 'flarum/common/utils/withAttr';
 import Stream from 'flarum/common/utils/Stream';
 import ExtensionPage from 'flarum/admin/components/ExtensionPage';
 import ItemList from 'flarum/common/utils/ItemList';
+import InspectMimeModal from './InspectMimeModal';
 
 /* global m */
 
@@ -205,6 +206,15 @@ export default class UploadPage extends ExtensionPage {
                   ])
                 ),
                 m('.helpText', app.translator.trans('fof-upload.admin.help_texts.mime_types')),
+                Button.component(
+                  {
+                    className: 'Button',
+                    onclick() {
+                      app.modal.show(InspectMimeModal);
+                    },
+                  },
+                  app.translator.trans('fof-upload.admin.labels.inspect-mime')
+                ),
                 m('.helpText', app.translator.trans('fof-upload.admin.help_texts.download_templates')),
                 this.templateOptionsDescriptions(),
               ]),

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -76,6 +76,7 @@ fof-upload:
           both: Both
           upload-btn: Upload button only
           media-btn: Media manager button only
+      inspect-mime: Test file MIME type
 
     permissions:
       download_label: Download files
@@ -110,6 +111,20 @@ fof-upload:
       local: Local
       ovh-svfs: OVH SVFS
       qiniu: QiNiu
+    inspect-mime:
+      title: Inspect MIME
+      description: |
+        FoF Upload uses the <a>PHP Mime Detector</a> library for common MIME types and PHP Fileinfo as a fallback.
+        The MIME value returned by Fileinfo can be different from server to server!
+      select: Select a file below to inspect the values that will be used. The file will not be saved.
+      laravel-validation: Laravel File Validation
+      no-file-selected: No file
+      validation-passed: Passed
+      validation-failed: "Failed: {error}"
+      mime-detector: Mime Detector (primary)
+      mime-fileinfo: PHP Fileinfo (fallback)
+      guessed-extension: Default file extension (if original is not whitelisted)
+      not-available: No result
   forum:
     media_manager: Media manager
 

--- a/src/Api/Controllers/InspectMimeController.php
+++ b/src/Api/Controllers/InspectMimeController.php
@@ -1,5 +1,15 @@
 <?php
 
+/*
+ * This file is part of fof/upload.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ * Copyright (c) Flagrow.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace FoF\Upload\Api\Controllers;
 
 use Exception;
@@ -50,7 +60,7 @@ class InspectMimeController implements RequestHandlerInterface
             $upload = $this->files->moveUploadedFileToTemp(Arr::first($files));
         } catch (ValidationException $exception) {
             return new JsonResponse([
-                'laravel_validation' => false,
+                'laravel_validation'       => false,
                 'laravel_validation_error' => $exception->getMessage(),
             ]);
         }

--- a/src/Api/Controllers/InspectMimeController.php
+++ b/src/Api/Controllers/InspectMimeController.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace FoF\Upload\Api\Controllers;
+
+use Exception;
+use Flarum\Http\RequestUtil;
+use FoF\Upload\Repositories\FileRepository;
+use Illuminate\Support\Arr;
+use Illuminate\Validation\ValidationException;
+use Laminas\Diactoros\Response\JsonResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UploadedFileInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use SoftCreatR\MimeDetector\MimeDetector;
+use SoftCreatR\MimeDetector\MimeDetectorException;
+
+class InspectMimeController implements RequestHandlerInterface
+{
+    /**
+     * @var FileRepository
+     */
+    protected $files;
+
+    /**
+     * @var MimeDetector
+     */
+    protected $mimeDetector;
+
+    public function __construct(FileRepository $files, MimeDetector $mimeDetector)
+    {
+        $this->files = $files;
+        $this->mimeDetector = $mimeDetector;
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        RequestUtil::getActor($request)->assertAdmin();
+
+        /**
+         * @var $files UploadedFileInterface[]
+         */
+        $files = Arr::get($request->getUploadedFiles(), 'files', []);
+
+        if (count($files) === 0) {
+            return new JsonResponse(null, 400);
+        }
+
+        try {
+            $upload = $this->files->moveUploadedFileToTemp(Arr::first($files));
+        } catch (ValidationException $exception) {
+            return new JsonResponse([
+                'laravel_validation' => false,
+                'laravel_validation_error' => $exception->getMessage(),
+            ]);
+        }
+
+        $data = [
+            'laravel_validation' => true,
+        ];
+
+        try {
+            $this->mimeDetector->setFile($upload->getPathname());
+
+            $uploadFileData = $this->mimeDetector->getFileType();
+
+            if (isset($uploadFileData['mime'])) {
+                $data['mime_detector'] = $uploadFileData['mime'];
+            }
+        } catch (MimeDetectorException $e) {
+            // Ignore errors. The value will be absent in response
+        }
+
+        try {
+            $data['php_mime'] = mime_content_type($upload->getPathname());
+        } catch (Exception $e) {
+            // Ignore errors. The value will be absent in response
+        }
+
+        try {
+            $data['guessed_extension'] = $upload->guessExtension() ?: 'bin';
+        } catch (Exception $e) {
+            // Ignore errors. The value will be absent in response
+        }
+
+        return new JsonResponse($data);
+    }
+}


### PR DESCRIPTION
**Changes proposed in this pull request:**
Add a new utility to the admin panel where files can be dropped to see their MIME type and guessed extension.

**Reviewers should focus on:**
The feature is mostly standalone. It re-uses the file repository but only to copy the file to the temporary folder. The file is never persisted to database or assets folder.

Are the labels explanatory enough? Is the placement of the test button good?

**Screenshot**
Example with common file:
![image](https://user-images.githubusercontent.com/5264300/154865536-6d156802-820a-49b4-a323-48a83dbdaf7b.png)
Example with fallback:
![image](https://user-images.githubusercontent.com/5264300/154865555-fbe3ce01-69fa-41e7-b4e7-617b59d0edcc.png)
Button to access the tool is below MIME configuration:
![image](https://user-images.githubusercontent.com/5264300/154865563-dc044bb2-f53e-4e8e-b87a-5d648a9a04e3.png)

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
