### PR TITLE
Update Imgur.php

### DIFF
--- a/src/Adapters/Imgur.php
+++ b/src/Adapters/Imgur.php
@@ -82,7 +82,7 @@ class Imgur implements UploadAdapter
 
             $link = Arr::get($meta, 'link');
 
-            $file->url = preg_replace('/^https?:/', null, $link);
+            $file->url = $link;
             $file->remote_id = Arr::get($meta, 'id');
         }
 


### PR DESCRIPTION
Removing http/https from image link making imgur image not appearing in the open graph image or twitter image meta tags and returning default image. SEO extension cannot get links started with the relative protocol. I removed preg_replace and it worked on my site. Please make changes to this file if there is no other issue.