### PR TITLE
Use Placeholder class for empty UserFileList

### DIFF
--- a/js/src/forum/components/UserFileList.js
+++ b/js/src/forum/components/UserFileList.js
@@ -52,13 +52,16 @@ export default class UserFileList extends Component {
         {this.inModal && state.empty() && (
           <p className="fof-upload-empty">
             <i className="fas fa-cloud-upload-alt fof-upload-empty-icon" />
-
             {app.translator.trans(`fof-upload.forum.file_list.modal_empty_${app.screen() !== 'phone' ? 'desktop' : 'phone'}`)}
           </p>
         )}
 
         {/* Empty file list */}
-        {!this.inModal && state.empty() && <p className="fof-upload-empty">{app.translator.trans('fof-upload.forum.file_list.empty')}</p>}
+        {!this.inModal && state.empty() && (
+          <div className="Placeholder">
+            <p className="fof-upload-empty">{app.translator.trans('fof-upload.forum.file_list.empty')}</p>
+          </div>
+        )}
 
         {/* File list */}
         <ul>


### PR DESCRIPTION
**Changes proposed in this pull request:**
Use Placeholder class for empty UserFileList, that will matches with Flarum

**Screenshot**
Before
<img width="790" alt="Screenshot 2022-04-30 020529" src="https://user-images.githubusercontent.com/56961917/166010155-22650b2d-4a59-4418-b9ec-2bbb5dd3c53e.png">
After
<img width="891" alt="Screenshot 2022-04-30 020543" src="https://user-images.githubusercontent.com/56961917/166010164-05b2e20e-9210-4646-9cdf-c44579a7044d.png">



**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
