### PR TITLE
fix: hides images from private posts or discussions

### DIFF
--- a/src/Api/Controllers/ListUploadsController.php
+++ b/src/Api/Controllers/ListUploadsController.php
@@ -67,13 +67,13 @@ class ListUploadsController extends AbstractListController
             // themselves and users with elevated permissions
             ->when(
                 $filterUploads != $actor->id && $actor->cannot('fof-upload.deleteUserUploads'),
-                fn($query) => $query->where('hide_from_media_manager', false)
+                fn ($query) => $query->where('hide_from_media_manager', false)
             )
             // Filter images contained in private discussions or posts, except for users
             // themselves or users with elevated permissions.
             ->when(
                 $filterUploads != $actor->id && $actor->cannot('fof-upload.deleteUserUploads'),
-                fn($query) => $query
+                fn ($query) => $query
                     ->whereHas('posts', fn ($query) => $query->where('posts.is_private', 0))
                     ->whereHas('posts.discussion', fn ($query) => $query->where('discussions.is_private', 0))
             )


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

https://discuss.flarum.org/d/4762-friendsofflarum-by-bu-well-integrated-advanced-private-discussions/1158

Hides images from discussions and posts that are private.

I haven't tested this yet.

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
