### PR TITLE
Allow TextEditor to be used in non-Composer contexts

### DIFF
--- a/js/src/forum/addUploadButton.js
+++ b/js/src/forum/addUploadButton.js
@@ -62,7 +62,13 @@ export default function () {
       }
     });
 
-    this.dragAndDrop = new DragAndDrop((files) => this.uploader.upload(files), this.$().parents('.Composer')[0]);
+    // Gracefully fail if the TextEditor was used in a non-Composer context
+    // Using a custom method to retrieve the target allows other extensions to still use this feature by returning an alternate container
+    const dragAndDropTarget = this.fofUploadDragAndDropTarget();
+
+    if (dragAndDropTarget) {
+      this.dragAndDrop = new DragAndDrop((files) => this.uploader.upload(files), dragAndDropTarget);
+    }
 
     new PasteClipboard((files) => this.uploader.upload(files), this.$('.TextEditor-editor')[0]);
   });
@@ -70,6 +76,12 @@ export default function () {
   extend(TextEditor.prototype, 'onremove', function (f_, vnode) {
     if (!app.forum.attribute('fof-upload.canUpload')) return;
 
-    this.dragAndDrop.unload();
+    if (this.dragAndDrop) {
+      this.dragAndDrop.unload();
+    }
   });
+
+  TextEditor.prototype.fofUploadDragAndDropTarget = function () {
+    return this.$().parents('.Composer')[0];
+  };
 }


### PR DESCRIPTION
**Changes proposed in this pull request:**
Modify the drag and drop implementation so that Flarum doesn't crash when trying to use `TextEditor` outside of the Composer.

Also make the drag and drop target customizable by extensions so that other extensions can make it work in their custom TextEditor locations.

Example implementation that would use the new function https://github.com/clarkwinkelmann/flarum-ext-composer-page/pull/1

**Reviewers should focus on:**
Should be 100% backward-compatible since it only adds new method and none of the code was previously extendable.

**Screenshot**
No visual changes.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
