### PR TITLE
fix: migrations assume flarum is already installed

### DIFF
--- a/migrations/2020_02_06_01_rename_flagrow_permissions.php
+++ b/migrations/2020_02_06_01_rename_flagrow_permissions.php
@@ -10,7 +10,6 @@
  * file that was distributed with this source code.
  */
 
-use Flarum\Group\Permission;
 use Illuminate\Database\Schema\Builder;
 
 return [

--- a/migrations/2020_02_06_01_rename_flagrow_permissions.php
+++ b/migrations/2020_02_06_01_rename_flagrow_permissions.php
@@ -15,10 +15,13 @@ use Illuminate\Database\Schema\Builder;
 
 return [
     'up' => function (Builder $schema) {
-        Permission::query()
+        $db = $schema->getConnection();
+
+        $db->table('group_permission')
             ->where('permission', 'flagrow.upload')
             ->update(['permission' => 'fof-upload.upload']);
-        Permission::query()
+
+        $db->table('group_permission')
             ->where('permission', 'flagrow.upload.download')
             ->update(['permission' => 'fof-upload.download']);
     },

--- a/migrations/2020_02_06_02_rename_flagrow_settings.php
+++ b/migrations/2020_02_06_02_rename_flagrow_settings.php
@@ -10,7 +10,6 @@
  * file that was distributed with this source code.
  */
 
-use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Database\Schema\Builder;
 
 return [
@@ -18,27 +17,27 @@ return [
         $db = $schema->getConnection();
 
         foreach ([
-                     'maxFileSize',
-                     'mimeTypes',
-                     'templates',
-                     'mustResize',
-                     'resizeMaxWidth',
-                     'cdnUrl',
-                     'addsWatermarks',
-                     'watermarkPosition',
-                     'watermark',
-                     'overrideAvatarUpload',
-                     'imgurClientId',
-                     'awsS3Key',
-                     'awsS3Secret',
-                     'awsS3Bucket',
-                     'awsS3Region',
-                     'disableHotlinkProtection',
-                     'disableDownloadLogging',
-                     'qiniuKey',
-                     'qiniuSecret',
-                     'qiniuBucket',
-                 ] as $key) {
+            'maxFileSize',
+            'mimeTypes',
+            'templates',
+            'mustResize',
+            'resizeMaxWidth',
+            'cdnUrl',
+            'addsWatermarks',
+            'watermarkPosition',
+            'watermark',
+            'overrideAvatarUpload',
+            'imgurClientId',
+            'awsS3Key',
+            'awsS3Secret',
+            'awsS3Bucket',
+            'awsS3Region',
+            'disableHotlinkProtection',
+            'disableDownloadLogging',
+            'qiniuKey',
+            'qiniuSecret',
+            'qiniuBucket',
+        ] as $key) {
             $db->table('settings')
                 ->where('key', 'flagrow.upload.'.$key)
                 ->update(['key' => 'fof-upload.'.$key]);

--- a/migrations/2020_02_06_02_rename_flagrow_settings.php
+++ b/migrations/2020_02_06_02_rename_flagrow_settings.php
@@ -15,39 +15,33 @@ use Illuminate\Database\Schema\Builder;
 
 return [
     'up' => function (Builder $schema) {
-        /**
-         * @var $settings SettingsRepositoryInterface
-         */
-        $settings = resolve(SettingsRepositoryInterface::class);
+        $db = $schema->getConnection();
 
         foreach ([
-            'maxFileSize',
-            'mimeTypes',
-            'templates',
-            'mustResize',
-            'resizeMaxWidth',
-            'cdnUrl',
-            'addsWatermarks',
-            'watermarkPosition',
-            'watermark',
-            'overrideAvatarUpload',
-            'imgurClientId',
-            'awsS3Key',
-            'awsS3Secret',
-            'awsS3Bucket',
-            'awsS3Region',
-            'disableHotlinkProtection',
-            'disableDownloadLogging',
-            'qiniuKey',
-            'qiniuSecret',
-            'qiniuBucket',
-        ] as $key) {
-            $value = $settings->get('flagrow.upload.'.$key);
-
-            if (!is_null($value)) {
-                $settings->set('fof-upload.'.$key, $value);
-                $settings->delete('flagrow.upload.'.$key);
-            }
+                     'maxFileSize',
+                     'mimeTypes',
+                     'templates',
+                     'mustResize',
+                     'resizeMaxWidth',
+                     'cdnUrl',
+                     'addsWatermarks',
+                     'watermarkPosition',
+                     'watermark',
+                     'overrideAvatarUpload',
+                     'imgurClientId',
+                     'awsS3Key',
+                     'awsS3Secret',
+                     'awsS3Bucket',
+                     'awsS3Region',
+                     'disableHotlinkProtection',
+                     'disableDownloadLogging',
+                     'qiniuKey',
+                     'qiniuSecret',
+                     'qiniuBucket',
+                 ] as $key) {
+            $db->table('settings')
+                ->where('key', 'flagrow.upload.'.$key)
+                ->update(['key' => 'fof-upload.'.$key]);
         }
     },
     'down' => function (Builder $schema) {


### PR DESCRIPTION
**Relates to https://github.com/flarum/framework/pull/3655**

**Changes proposed in this pull request:**
The current migrations assume Flarum is already installed and resolve dependencies that are only available then. This makes it impossible to directly install an instance with the extension. This PR makes sure the database connection provided is the one used to make the needed changes without resolving anything else.

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
