### PR TITLE
fix: descriptive upload error messages

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -20,6 +20,8 @@ use Flarum\Post\Event\Posted;
 use Flarum\Post\Event\Revised;
 use Flarum\Settings\Event\Deserializing;
 use FoF\Upload\Events\File\WillBeUploaded;
+use FoF\Upload\Exceptions\ExceptionHandler;
+use FoF\Upload\Exceptions\InvalidUploadException;
 use FoF\Upload\Extend\SvgSanitizer;
 
 return [
@@ -80,4 +82,7 @@ return [
 
     (new SvgSanitizer())
         ->allowTag('animate'),
+
+    (new Extend\ErrorHandling())
+        ->handler(InvalidUploadException::class, ExceptionHandler::class),
 ];

--- a/js/src/forum/handler/Uploader.js
+++ b/js/src/forum/handler/Uploader.js
@@ -45,7 +45,16 @@ export default class Uploader {
         this.uploading = false;
         m.redraw();
 
-        throw error;
+        const e = error.response.errors[0];
+
+        if (! e.code.includes('fof-upload')) {
+            throw error;
+        }
+
+        app.alerts.clear();
+        app.alerts.show({
+            type: 'error',
+        }, e.detail);
       });
   }
 

--- a/js/src/forum/handler/Uploader.js
+++ b/js/src/forum/handler/Uploader.js
@@ -47,14 +47,17 @@ export default class Uploader {
 
         const e = error.response.errors[0];
 
-        if (! e.code.includes('fof-upload')) {
-            throw error;
+        if (!e.code.includes('fof-upload')) {
+          throw error;
         }
 
         app.alerts.clear();
-        app.alerts.show({
+        app.alerts.show(
+          {
             type: 'error',
-        }, e.detail);
+          },
+          e.detail
+        );
       });
   }
 

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -174,3 +174,11 @@ fof-upload:
       forbidden_type: Uploading files of this type is not allowed.
       unsupported_type: "Upload adapter does not support the provided mime type: {mime}."
       could_not_detect_mime: Could not detect the MIME type of this file, please try again.
+      max_upload_file_size_ini: Upload max filesize limit reached from php.ini.
+      max_upload_file_size_form: Upload max filesize limit reached from form.
+      partial_upload: Partial upload.
+      no_file_uploaded: No file uploaded.
+      no_upload_tmp_folder: No tmp folder for uploading files.
+      cannot_write_to_disk: Cannot write to disk.
+      upload_blocked_by_php_extension: A php extension blocked the upload.
+      no_files_made_it_to_upload: Please upload files no larger than {max} kb.

--- a/src/Api/Controllers/UploadController.php
+++ b/src/Api/Controllers/UploadController.php
@@ -62,7 +62,7 @@ class UploadController extends AbstractListController
 
         if ($collection->isEmpty()) {
             throw new InvalidUploadException('no_files_made_it_to_upload', 400, [
-                'max' => $this->settings->get('fof-upload.maxFileSize', Util::DEFAULT_MAX_FILE_SIZE)
+                'max' => $this->settings->get('fof-upload.maxFileSize', Util::DEFAULT_MAX_FILE_SIZE),
             ]);
         }
 

--- a/src/Api/Controllers/UploadController.php
+++ b/src/Api/Controllers/UploadController.php
@@ -13,9 +13,11 @@
 namespace FoF\Upload\Api\Controllers;
 
 use Flarum\Api\Controller\AbstractListController;
+use Flarum\Settings\SettingsRepositoryInterface;
 use FoF\Upload\Api\Serializers\FileSerializer;
 use FoF\Upload\Commands\Upload;
 use FoF\Upload\Exceptions\InvalidUploadException;
+use FoF\Upload\Helpers\Util;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
@@ -31,9 +33,15 @@ class UploadController extends AbstractListController
      */
     protected $bus;
 
-    public function __construct(Dispatcher $bus)
+    /**
+     * @var SettingsRepositoryInterface
+     */
+    protected $settings;
+
+    public function __construct(Dispatcher $bus, SettingsRepositoryInterface $settings)
     {
         $this->bus = $bus;
+        $this->settings = $settings;
     }
 
     /**
@@ -53,7 +61,9 @@ class UploadController extends AbstractListController
         );
 
         if ($collection->isEmpty()) {
-            throw new InvalidUploadException('No files were uploaded');
+            throw new InvalidUploadException('no_files_made_it_to_upload', 400, [
+                'max' => $this->settings->get('fof-upload.maxFileSize', Util::DEFAULT_MAX_FILE_SIZE)
+            ]);
         }
 
         return $collection;

--- a/src/Exceptions/ExceptionHandler.php
+++ b/src/Exceptions/ExceptionHandler.php
@@ -1,5 +1,15 @@
 <?php
 
+/*
+ * This file is part of fof/upload.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ * Copyright (c) Flagrow.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace FoF\Upload\Exceptions;
 
 use Flarum\Foundation\ErrorHandling\HandledError;

--- a/src/Exceptions/ExceptionHandler.php
+++ b/src/Exceptions/ExceptionHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace FoF\Upload\Exceptions;
+
+use Flarum\Foundation\ErrorHandling\HandledError;
+
+class ExceptionHandler
+{
+    public function handle(InvalidUploadException $e): HandledError
+    {
+        return (new HandledError(
+            $e,
+            "fof-upload.$e->type",
+            $e->status
+        ))->withDetails($this->errorDetails($e));
+    }
+
+    protected function errorDetails(InvalidUploadException $e): array
+    {
+        $errors = $e->errors();
+
+        return array_map(function (string $field, array $messages): array {
+            return [
+                'detail' => implode("\n", $messages),
+                'source' => ['pointer' => "/data/attributes/$field"]
+            ];
+        }, array_keys($errors), $errors);
+    }
+}

--- a/src/Exceptions/InvalidUploadException.php
+++ b/src/Exceptions/InvalidUploadException.php
@@ -12,6 +12,34 @@
 
 namespace FoF\Upload\Exceptions;
 
+use Symfony\Contracts\Translation\TranslatorInterface;
+
 class InvalidUploadException extends \Exception
 {
+    public $type = null;
+    public $status = null;
+    public $params = [];
+
+    public function __construct(string $type, int $status, array $params = [])
+    {
+        $this->type = $type;
+        $this->status = $status;
+        $this->params = $params;
+
+        parent::__construct(
+            $this->constructMessage()
+        );
+    }
+
+    public function errors(): array
+    {
+        return [
+            'upload' => [$this->getMessage()]
+        ];
+    }
+
+    protected function constructMessage()
+    {
+        return resolve(TranslatorInterface::class)->trans('fof-upload.api.upload_errors.'.$this->type, $this->params);
+    }
 }

--- a/src/Exceptions/InvalidUploadException.php
+++ b/src/Exceptions/InvalidUploadException.php
@@ -34,7 +34,7 @@ class InvalidUploadException extends \Exception
     public function errors(): array
     {
         return [
-            'upload' => [$this->getMessage()]
+            'upload' => [$this->getMessage()],
         ];
     }
 

--- a/src/Repositories/FileRepository.php
+++ b/src/Repositories/FileRepository.php
@@ -148,30 +148,23 @@ class FileRepository
      *
      * @throws InvalidUploadException
      */
-    protected function handleUploadError($code)
+    protected function handleUploadError($code): void
     {
         switch ($code) {
             case UPLOAD_ERR_INI_SIZE:
-                throw new InvalidUploadException('Upload max filesize limit reached from php.ini.');
-                break;
+                throw new InvalidUploadException('max_upload_file_size_ini', 413);
             case UPLOAD_ERR_FORM_SIZE:
-                throw new InvalidUploadException('Upload max filesize limit reached from form.');
-                break;
+                throw new InvalidUploadException('max_upload_file_size_form', 413);
             case UPLOAD_ERR_PARTIAL:
-                throw new InvalidUploadException('Partial upload.');
-                break;
+                throw new InvalidUploadException('partial_upload', 206);
             case UPLOAD_ERR_NO_FILE:
-                throw new InvalidUploadException('No file uploaded.');
-                break;
+                throw new InvalidUploadException('no_file_uploaded', 400);
             case UPLOAD_ERR_NO_TMP_DIR:
-                throw new InvalidUploadException('No tmp folder for uploading files.');
-                break;
+                throw new InvalidUploadException('no_upload_tmp_folder', 500);
             case UPLOAD_ERR_CANT_WRITE:
-                throw new InvalidUploadException('Cannot write to disk');
-                break;
+                throw new InvalidUploadException('cannot_write_to_disk', 500);
             case UPLOAD_ERR_EXTENSION:
-                throw new InvalidUploadException('A php extension blocked the upload.');
-                break;
+                throw new InvalidUploadException('upload_blocked_by_php_extension', 500);
             case UPLOAD_ERR_OK:
                 break;
         }


### PR DESCRIPTION
**Fixes #141**

**Changes proposed in this pull request:**
Handles the `InvalidUploadException` for end user consumption rather than a non-understandable 500.

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
