### PR TITLE
DB S3 key should not be forced

### DIFF
--- a/src/Adapters/Manager.php
+++ b/src/Adapters/Manager.php
@@ -103,10 +103,6 @@ class Manager
      */
     protected function awsS3(Util $util)
     {
-        if (!$this->settings->get('fof-upload.awsS3Key')) {
-            return null;
-        }
-
         $s3Config = [
             'region'                  => empty($this->settings->get('fof-upload.awsS3Region')) ? null : $this->settings->get('fof-upload.awsS3Region'),
             'version'                 => 'latest',


### PR DESCRIPTION
In cases where AWS configuration is done on server/env the S3 driver should still be instantiable.

<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
Update src/Adapters/Manager.php to not return null when the DB S3 key is not set. This is because the aws-sdk falls back on $_ENV and system configuration (~/.aws/config) for initialization for added security.

**Reviewers should focus on:**
It appears this method was already set up to do so, but was later updated to return early.

**Screenshot**
n/a

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
