### PR TITLE
feat: add translations, support file deletion via gdpr

### DIFF
--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -1,3 +1,11 @@
+blomstra-gdpr:
+  lib:
+    data:
+      uploads:
+        export_description: All files uploaded by the user.
+        anonymize_description: Removes the user reference from the uploaded files. The files themselves remain accessible to users that could view them pre-anonymization.
+        delete_description: Deletes all files uploaded by the user.
+
 fof-upload:
   admin:
     pane:


### PR DESCRIPTION
Requires `blomstra/gdpr` `0.1.0-beta.18` or higher in order to enable the support