### PR TITLE
perf: eager load file counts

### DIFF
--- a/src/Extenders/AddForumAttributes.php
+++ b/src/Extenders/AddForumAttributes.php
@@ -36,6 +36,9 @@ class AddForumAttributes
         $attributes['fof-upload.canDownload'] = $serializer->getActor()->can('fof-upload.download');
         $attributes['fof-upload.composerButtonVisiblity'] = $this->settings->get('fof-upload.composerButtonVisiblity', 'both');
 
+        $serializer->getActor()->load('foffiles');
+        $serializer->getActor()->load('foffilesCurrent');
+
         return $attributes;
     }
 }

--- a/src/Extenders/AddUserAttributes.php
+++ b/src/Extenders/AddUserAttributes.php
@@ -20,8 +20,8 @@ class AddUserAttributes
 {
     public function __invoke(UserSerializer $serializer, User $user, array $attributes): array
     {
-        $attributes['fof-upload-uploadCountCurrent'] = File::where('actor_id', $user->id)->where('hide_from_media_manager', false)->count();
-        $attributes['fof-upload-uploadCountAll'] = File::where('actor_id', $user->id)->count();
+        $attributes['fof-upload-uploadCountCurrent'] = $user->foffiles_current_count;
+        $attributes['fof-upload-uploadCountAll'] = $user->foffiles_count;
 
         return $attributes;
     }

--- a/src/Extenders/AddUserAttributes.php
+++ b/src/Extenders/AddUserAttributes.php
@@ -14,7 +14,6 @@ namespace FoF\Upload\Extenders;
 
 use Flarum\Api\Serializer\UserSerializer;
 use Flarum\User\User;
-use FoF\Upload\File;
 
 class AddUserAttributes
 {

--- a/src/Extenders/LoadFilesRelationship.php
+++ b/src/Extenders/LoadFilesRelationship.php
@@ -1,5 +1,15 @@
 <?php
 
+/*
+ * This file is part of fof/upload.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ * Copyright (c) Flagrow.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace FoF\Upload\Extenders;
 
 use Flarum\Api\Controller\ListDiscussionsController;
@@ -17,7 +27,7 @@ class LoadFilesRelationship
         } elseif (is_array($data) && isset($data['actor'])) {
             $loadable = $data['actor'];
         } elseif ($controller instanceof ListPostsController || $controller instanceof ListDiscussionsController) {
-            $loadable = (new User)->newCollection($data->pluck('user'));
+            $loadable = (new User())->newCollection($data->pluck('user'));
         }
 
         if ($loadable) {

--- a/src/Extenders/LoadFilesRelationship.php
+++ b/src/Extenders/LoadFilesRelationship.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace FoF\Upload\Extenders;
+
+use Flarum\Api\Controller\ListDiscussionsController;
+use Flarum\Api\Controller\ListPostsController;
+use Flarum\User\User;
+
+class LoadFilesRelationship
+{
+    public static function countRelations($controller, $data): void
+    {
+        $loadable = null;
+
+        if ($data instanceof User) {
+            $loadable = $data;
+        } elseif (is_array($data) && isset($data['actor'])) {
+            $loadable = $data['actor'];
+        } elseif ($controller instanceof ListPostsController || $controller instanceof ListDiscussionsController) {
+            $loadable = (new User)->newCollection($data->pluck('user'));
+        }
+
+        if ($loadable) {
+            $loadable->loadCount('foffiles');
+            $loadable->loadCount('foffilesCurrent');
+        }
+    }
+}


### PR DESCRIPTION
**Screenshot**
![image](https://github.com/FriendsOfFlarum/upload/assets/20267363/3583a63c-75dc-4ffe-a48b-b39eb2c13bd0)



![image](https://github.com/FriendsOfFlarum/upload/assets/20267363/47ac90f2-320d-426c-a484-f4e0e14c7a11)


**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
