### PR TITLE
fix: collection might contain null values when eager loading

### DIFF
--- a/src/Extenders/LoadFilesRelationship.php
+++ b/src/Extenders/LoadFilesRelationship.php
@@ -27,7 +27,7 @@ class LoadFilesRelationship
         } elseif (is_array($data) && isset($data['actor'])) {
             $loadable = $data['actor'];
         } elseif ($controller instanceof ListPostsController || $controller instanceof ListDiscussionsController) {
-            $loadable = (new User())->newCollection($data->pluck('user'));
+            $loadable = (new User())->newCollection($data->pluck('user'))->filter();
         }
 
         if ($loadable) {


### PR DESCRIPTION
**Changes proposed in this pull request:**
Plucking seems to include null values as well, so we need to filter the collection.

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
