### PR TITLE
Fix fallback mime detection

### DIFF
--- a/src/Commands/UploadHandler.php
+++ b/src/Commands/UploadHandler.php
@@ -107,7 +107,7 @@ class UploadHandler
 
                 $uploadFileData = $this->mimeDetector->getFileType();
 
-                if (Arr::get($uploadFileData, 'mime')) {
+                if (!Arr::has($uploadFileData, 'mime')) {
                     try {
                         $uploadFileData['mime'] = mime_content_type($upload->getPathname());
                     } catch (Exception $e) {


### PR DESCRIPTION
The $this->mimeDetector returns an empty array when it does not match any file type. To actually fallback to finfo we have to check if the mime key is not present.

To reproduce, upload a simple txt file and observe an exception when the non existing mime key is accessed.
