### PR TITLE
fix: missing translations

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -112,8 +112,7 @@ return [
         ->handler(InvalidUploadException::class, ExceptionHandler::class),
 
     (new Extend\Settings())
-        ->default('fof-upload.maxFileSize', Util::DEFAULT_MAX_FILE_SIZE)
-        ->default('fof-upload.mimeTypes', Util::defaultMimeTypes()),
+        ->default('fof-upload.maxFileSize', Util::DEFAULT_MAX_FILE_SIZE),
 
     new Extenders\AddPostDownloadTags(),
     new Extenders\CreateStorageFolder('tmp'),

--- a/js/src/admin/components/UploadPage.js
+++ b/js/src/admin/components/UploadPage.js
@@ -93,7 +93,13 @@ export default class UploadPage extends ExtensionPage {
     // Set a sane default in case no mimeTypes have been configured yet.
     // Since 'local' (or others) can now be disabled, pick the last entry in the object for default
     this.defaultAdap = Object.keys(this.uploadMethodOptions)[Object.keys(this.uploadMethodOptions).length - 1];
-    this.values.mimeTypes();
+    this.values.mimeTypes() ||
+      (this.values.mimeTypes = Stream({
+        '^image\\/.*': {
+          adapter: this.defaultAdap,
+          template: 'image-preview',
+        },
+      }));
 
     this.newMimeType = {
       regex: Stream(''),

--- a/src/Helpers/Util.php
+++ b/src/Helpers/Util.php
@@ -74,18 +74,16 @@ class Util
         )->filter();
     }
 
-    public function defaultMimeTypes(): string
+    public function defaultMimeTypes(): Collection
     {
         $adapters = $this->getAvailableUploadMethods();
 
-        return json_encode(
-            [
-                '^image\/.*' => [
-                    'adapter'  => $adapters->flip()->last(),
-                    'template' => 'image-preview',
-                ],
-            ]
-        );
+        return collect([
+            '^image\/.*' => [
+                'adapter'  => $adapters->flip()->last(),
+                'template' => 'image-preview',
+            ],
+        ]);
     }
 
     /**

--- a/src/Helpers/Util.php
+++ b/src/Helpers/Util.php
@@ -35,7 +35,7 @@ class Util
     /**
      * @return Collection
      */
-    public static function getAvailableUploadMethods()
+    public function getAvailableUploadMethods()
     {
         return resolve(Manager::class)->adapters()
             ->filter(function ($available) {
@@ -70,12 +70,13 @@ class Util
 
         return $this->getJsonValue(
             $mimeTypes,
+            $this->defaultMimeTypes()
         )->filter();
     }
 
-    public static function defaultMimeTypes(): string
+    public function defaultMimeTypes(): string
     {
-        $adapters = self::getAvailableUploadMethods();
+        $adapters = $this->getAvailableUploadMethods();
 
         return json_encode(
             [

--- a/src/Providers/DownloadProvider.php
+++ b/src/Providers/DownloadProvider.php
@@ -15,14 +15,6 @@ namespace FoF\Upload\Providers;
 use Flarum\Foundation\AbstractServiceProvider;
 use FoF\Upload\Commands\DownloadHandler;
 use FoF\Upload\Downloader\DefaultDownloader;
-use FoF\Upload\Helpers\Util;
-use FoF\Upload\Templates\BbcodeImageTemplate;
-use FoF\Upload\Templates\FileTemplate;
-use FoF\Upload\Templates\ImagePreviewTemplate;
-use FoF\Upload\Templates\ImageTemplate;
-use FoF\Upload\Templates\JustUrlTemplate;
-use FoF\Upload\Templates\MarkdownImageTemplate;
-use FoF\Upload\Templates\TextPreviewTemplate;
 
 class DownloadProvider extends AbstractServiceProvider
 {
@@ -31,16 +23,5 @@ class DownloadProvider extends AbstractServiceProvider
         DownloadHandler::addDownloader(
             $this->container->make(DefaultDownloader::class)
         );
-
-        /** @var Util $util */
-        $util = $this->container->make(Util::class);
-
-        $util->addRenderTemplate($this->container->make(FileTemplate::class));
-        $util->addRenderTemplate($this->container->make(ImageTemplate::class));
-        $util->addRenderTemplate($this->container->make(ImagePreviewTemplate::class));
-        $util->addRenderTemplate($this->container->make(JustUrlTemplate::class));
-        $util->addRenderTemplate($this->container->make(MarkdownImageTemplate::class));
-        $util->addRenderTemplate($this->container->make(BbcodeImageTemplate::class));
-        $util->addRenderTemplate($this->container->make(TextPreviewTemplate::class));
     }
 }

--- a/src/Providers/UtilProvider.php
+++ b/src/Providers/UtilProvider.php
@@ -14,11 +14,25 @@ namespace FoF\Upload\Providers;
 
 use Flarum\Foundation\AbstractServiceProvider;
 use FoF\Upload\Helpers\Util;
+use FoF\Upload\Templates;
+use Illuminate\Contracts\Container\Container;
 
 class UtilProvider extends AbstractServiceProvider
 {
     public function register()
     {
-        $this->container->singleton(Util::class);
+        $this->container->singleton(Util::class, function (Container $container) {
+            $util = new Util();
+
+            $util->addRenderTemplate($container->make(Templates\FileTemplate::class));
+            $util->addRenderTemplate($container->make(Templates\ImageTemplate::class));
+            $util->addRenderTemplate($container->make(Templates\ImagePreviewTemplate::class));
+            $util->addRenderTemplate($container->make(Templates\JustUrlTemplate::class));
+            $util->addRenderTemplate($container->make(Templates\MarkdownImageTemplate::class));
+            $util->addRenderTemplate($container->make(Templates\BbcodeImageTemplate::class));
+            $util->addRenderTemplate($container->make(Templates\TextPreviewTemplate::class));
+
+            return $util;
+        });
     }
 }

--- a/tests/integration/api/FileUploadTest.php
+++ b/tests/integration/api/FileUploadTest.php
@@ -97,7 +97,6 @@ class FileUploadTest extends EnhancedTestCase
 
         $json = json_decode($response->getBody()->getContents(), true);
 
-        $this->assertArrayHasKey('data', $json);
         $this->assertCount(1, $json['data']);
         $this->assertArrayHasKey('attributes', $json['data'][0]);
 

--- a/tests/integration/api/ForumAttributesTest.php
+++ b/tests/integration/api/ForumAttributesTest.php
@@ -55,7 +55,7 @@ class ForumAttributesTest extends TestCase
                 '/'
             )
         );
-        
+
         $this->assertEquals(200, $response->getStatusCode());
 
         $this->assertStringContainsString('<h1>All Discussions</h1>', $response->getBody()->getContents());

--- a/tests/integration/api/ForumAttributesTest.php
+++ b/tests/integration/api/ForumAttributesTest.php
@@ -43,4 +43,21 @@ class ForumAttributesTest extends TestCase
         $this->assertArrayHasKey('fof-upload.canDownload', $json['data']['attributes']);
         $this->assertArrayHasKey('fof-upload.composerButtonVisiblity', $json['data']['attributes']);
     }
+
+    /**
+     * @test
+     */
+    public function forum_frontend_is_alive()
+    {
+        $response = $this->send(
+            $this->request(
+                'GET',
+                '/'
+            )
+        );
+        
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $this->assertStringContainsString('<h1>All Discussions</h1>', $response->getBody()->getContents());
+    }
 }


### PR DESCRIPTION
For some reason, with the last changes none of the translations load when the extension is enabled...
![image](https://github.com/FriendsOfFlarum/upload/assets/16573496/7500a737-617c-4d16-90f9-5e3c516f3b5a)
