### PR TITLE
fix: insert BBCode on paste

### DIFF
--- a/js/src/forum/handler/Uploader.js
+++ b/js/src/forum/handler/Uploader.js
@@ -49,7 +49,6 @@ export default class Uploader {
         this.uploading = false;
         m.redraw();
 
-        console.log(error);
         const e = error.response.errors[0];
 
         if (!e.code.includes('fof-upload')) {

--- a/js/src/forum/handler/Uploader.js
+++ b/js/src/forum/handler/Uploader.js
@@ -49,6 +49,7 @@ export default class Uploader {
         this.uploading = false;
         m.redraw();
 
+        console.log(error);
         const e = error.response.errors[0];
 
         if (!e.code.includes('fof-upload')) {
@@ -72,7 +73,7 @@ export default class Uploader {
       const fileObj = app.store.pushObject(file);
 
       // Add file to media manager
-      this.fileState.addToList(fileObj);
+      this.fileState?.addToList(fileObj);
 
       // Dispatch
       this.dispatch('success', {


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
This PR fixes the insertion of BBCode after pasting image from clipboard.
After update to v1.5.0 it stopped working.

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->
https://github.com/FriendsOfFlarum/upload/assets/25438601/51a2158f-167e-4104-9d3b-323acc3df1dd


**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.

