### PR TITLE
Fix: delete file button confirmation message and prevent selecting file on delete

### DIFF
--- a/js/src/common/components/DisplayFile.tsx
+++ b/js/src/common/components/DisplayFile.tsx
@@ -9,6 +9,7 @@ import User from 'flarum/common/models/User';
 import ItemList from 'flarum/common/utils/ItemList';
 import type Mithril from 'mithril';
 import Tooltip from 'flarum/common/components/Tooltip';
+import extractText from 'flarum/common/utils/extractText';
 
 interface CustomAttrs extends ComponentAttrs {
   file: File;
@@ -183,7 +184,7 @@ export default class DisplayFile extends Component<CustomAttrs> {
   }
 
   async confirmDelete() {
-    let result = confirm('Are you sure you want to delete this file?');
+    let result = confirm(extractText(app.translator.trans('fof-upload.lib.file_list.delete_confirmation', { fileName: this.file.baseName() })));
 
     if (result) {
       const uuid = this.file.uuid();

--- a/js/src/common/components/DisplayFile.tsx
+++ b/js/src/common/components/DisplayFile.tsx
@@ -147,7 +147,7 @@ export default class DisplayFile extends Component<CustomAttrs> {
           icon="fas fa-trash"
           aria-label={app.translator.trans('fof-upload.lib.file_list.delete_file_a11y_label', { fileName: file.baseName() })}
           disabled={this.isFileHiding}
-          onclick={() => this.confirmDelete()}
+          onclick={(e: MouseEvent) => this.confirmDelete(e)}
         />,
         60
       );
@@ -183,10 +183,10 @@ export default class DisplayFile extends Component<CustomAttrs> {
     }
   }
 
-  async confirmDelete() {
-    let result = confirm(extractText(app.translator.trans('fof-upload.lib.file_list.delete_confirmation', { fileName: this.file.baseName() })));
+  async confirmDelete(e: MouseEvent) {
+    e.stopPropagation();
 
-    if (result) {
+    if (confirm(extractText(app.translator.trans('fof-upload.lib.file_list.delete_confirmation', { fileName: this.file.baseName() })))) {
       const uuid = this.file.uuid();
       await app.request({
         method: 'DELETE',

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -206,6 +206,7 @@ fof-upload:
       confirm_selection_btn: "{fileCount, plural, =0 {None selected} one {Select file} other {Select files}}"
       load_more_files_btn: Load more files
       delete_file_a11y_label: Delete file "{fileName}"
+      delete_confirmation: Are you sure you want to delete "{fileName}"?
 
       hide_file:
         btn_a11y_label_hide: Hide "{fileName}" from media manager


### PR DESCRIPTION
**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

- Use translation instead of hardcoded text in the delete file confirmation
- Prevent selecting file on delete 

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.