### PR TITLE
fix(routing): use slug for routing on UserPage

### DIFF
--- a/js/src/forum/addUserPageButton.js
+++ b/js/src/forum/addUserPageButton.js
@@ -16,7 +16,7 @@ export default function addUserPageButton() {
         LinkButton.component(
           {
             href: app.route('user.uploads', {
-              username: this.user.username(),
+              username: this.user.slug(),
             }),
             name: 'uploads',
             icon: 'fas fa-file-upload',


### PR DESCRIPTION
Summary:

- Use slug instead of username to ensure compatibility no matter if the slug driver is left to default or id.