### PR TITLE
Fix Condition when Text Preview should be shown

### DIFF
--- a/src/Formatter/TextPreview/FormatTextPreview.php
+++ b/src/Formatter/TextPreview/FormatTextPreview.php
@@ -43,18 +43,15 @@ class FormatTextPreview
             $snippet = '';
 
             if ($file) {
-                $file_contents = file_get_contents($this->paths->public.'/assets/files/'.$file->path);
+                $file_contents = file_get_contents($this->paths->public . '/assets/files/' . $file->path);
+                $lines = preg_split('/\R/', $file_contents);
+                $lines = array_filter($lines, 'trim');
 
-                $file_contents_normalised = str_replace(["\r\n", "\r", "\n"], "\n", $file_contents);
-
-                // automatically normalises line endings
-                $lines = explode("\n", $file_contents_normalised);
-                $first_five_lines = array_slice($lines, 0, 5);
-                $snippet = implode("\n", $first_five_lines);
-
-                if ($snippet == $file_contents_normalised) {
+                if (count($lines) <= 5) {
                     $attributes['has_snippet'] = 'false';
                 }
+
+                $snippet = implode("\n", array_slice($lines, 0, 5));
             }
 
             $attributes['snippet'] = $snippet;

--- a/src/Formatter/TextPreview/FormatTextPreview.php
+++ b/src/Formatter/TextPreview/FormatTextPreview.php
@@ -52,7 +52,7 @@ class FormatTextPreview
                 $first_five_lines = array_slice($lines, 0, 5);
                 $snippet = implode("\n", $first_five_lines);
 
-                if ($snippet !== $file_contents_normalised) {
+                if ($snippet == $file_contents_normalised) {
                     $attributes['has_snippet'] = 'false';
                 }
             }

--- a/src/Formatter/TextPreview/FormatTextPreview.php
+++ b/src/Formatter/TextPreview/FormatTextPreview.php
@@ -43,7 +43,7 @@ class FormatTextPreview
             $snippet = '';
 
             if ($file) {
-                $file_contents = file_get_contents($this->paths->public . '/assets/files/' . $file->path);
+                $file_contents = file_get_contents($this->paths->public.'/assets/files/'.$file->path);
                 $lines = preg_split('/\R/', $file_contents);
                 $lines = array_filter($lines, 'trim');
 


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
Fixes the "expand" button's misbehavior while using Text Preview.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
