### PR TITLE
fix: readme implies wrong composer require command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ An extension that handles file uploads intelligently for your forum.
 Install manually:
 
 ```sh
-composer require fof/upload "*"
+composer require fof/upload:"*"
 ```
 
 ## Updating
 
 ```sh
-composer require fof/upload "*"
+composer require fof/upload:"*"
 php flarum migrate
 php flarum cache:clear
 ```


### PR DESCRIPTION
require accept multiple packages as arguments, using a space will tell composer to install both fof/upload and "*". Using the : delimiter will help it understand the wildcard as version constraint.

https://getcomposer.org/doc/03-cli.md#require-r

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
