### PR TITLE
fix: filename is unreadable text when downloading a file with a non-ascii name

### DIFF
--- a/src/Downloader/DefaultDownloader.php
+++ b/src/Downloader/DefaultDownloader.php
@@ -101,7 +101,7 @@ class DefaultDownloader implements Downloader
 
         $response = $response->withHeader(
             'Content-Disposition',
-            sprintf('attachment; filename="%s"', $file->base_name)
+            sprintf('attachment; filename="%s"; filename*=utf-8\'\'%s', $file->base_name, urlencode($file->base_name))
         );
 
         return $response;


### PR DESCRIPTION
Adding a field of "filename*" for the response header "Content-Disposition" to fix such problem.