### PR TITLE
fix: change UI in tooltips of uploaded files

### DIFF
--- a/resources/less/common/fileList.less
+++ b/resources/less/common/fileList.less
@@ -14,7 +14,7 @@
       align-items: center;
       justify-content: center;
       border-radius: @border-radius;
-      overflow: hidden;
+      overflow: visible;
       box-shadow: 0 2px 4px @shadow-color;
       border: 2px solid transparent; // Transparent border to maintain spacing when selected
       transition: box-shadow 150ms ease-in-out;
@@ -70,6 +70,12 @@
 
         .tooltip {
           overflow: visible !important;
+
+          .tooltip-inner {
+            text-overflow: ellipsis;
+            overflow: hidden;
+            text-wrap: wrap;
+          }
         }
       }
   


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
Fix UI issue with tooltips of uploaded files (both in the Forum & Admin Frontend)

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
Before:
<img width="209" alt="Screenshot 2024-11-10 at 10 49 40" src="https://github.com/user-attachments/assets/dd595606-1035-4ff6-83d1-aff3766f1daa">

After:
<img width="227" alt="Screenshot 2024-11-10 at 10 49 09" src="https://github.com/user-attachments/assets/326982a7-065b-49fb-bddf-97167efea56d">

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
