### PR TITLE
fix: append new results when loading more to existing files

### DIFF
--- a/js/src/common/components/AbstractFIleList.tsx
+++ b/js/src/common/components/AbstractFIleList.tsx
@@ -100,15 +100,15 @@ export default abstract class AbstractFileList extends Component<FileListAttrs> 
               </li>
             );
           })}
-          {/* Load more files */}
-          {this.hasMoreResults() && (
-            <div className={'fof-load-more-files'}>
-              <Button className={'Button Button--primary'} disabled={this.isLoading()} loading={this.isLoading()} onclick={() => this.loadMore()}>
-                {app.translator.trans('fof-upload.lib.file_list.load_more_files_btn')}
-              </Button>
-            </div>
-          )}
         </ul>
+        {/* Load more files */}
+        {this.hasMoreResults() && (
+          <div className={'fof-load-more-files'}>
+            <Button className={'Button Button--primary'} disabled={this.isLoading()} loading={this.isLoading()} onclick={() => this.loadMore()}>
+              {app.translator.trans('fof-upload.lib.file_list.load_more_files_btn')}
+            </Button>
+          </div>
+        )}
       </div>
     );
   }

--- a/js/src/common/states/FileListState.ts
+++ b/js/src/common/states/FileListState.ts
@@ -75,7 +75,7 @@ export default class FileListState {
   }
 
   private parseResults(results: ApiResponsePlural<File>): ApiResponsePlural<File> {
-    this.files = results;
+    this.files = this.files.concat(results);
     this.loading = false;
     this.moreResults = !!results.payload?.links?.next;
     m.redraw();

--- a/resources/less/common/fileList.less
+++ b/resources/less/common/fileList.less
@@ -120,4 +120,10 @@
             z-index: 3; // Loading indicator should be on top of all
         }
     }
+
+    .fof-load-more-files {
+        display: flex;
+        justify-content: center;
+        margin-bottom: 16px;
+    }
 }


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes https://github.com/FriendsOfFlarum/upload/issues/395**

**Changes proposed in this pull request:**
- Add load more button below file grid
- Append new results when loading more to existing files

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
