### PR TITLE
feat: begin to move away from hard coded base urls

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -8,6 +8,6 @@ jobs:
     with:
       enable_backend_testing: true
       enable_phpstan: true
-      php_versions: '["8.0", "8.1", "8.2", "8.3"]'
+      php_versions: '["8.1", "8.2", "8.3"]'
 
       backend_directory: .

--- a/extend.php
+++ b/extend.php
@@ -107,6 +107,7 @@ return [
         ->attributes(Extenders\AddUserAttributes::class),
 
     (new Extend\Formatter())
+        ->render(Formatter\ImagePreview\FormatImagePreview::class)
         ->render(Formatter\TextPreview\FormatTextPreview::class),
 
     (new SvgSanitizer())

--- a/resources/templates/image-preview.blade.php
+++ b/resources/templates/image-preview.blade.php
@@ -1,1 +1,1 @@
-<img src="{@url}" title="{@base_name}" alt="{@base_name}"/>
+<img class="FoFUpload--Upl-Image-Preview" src="{@url}" title="{@title}" alt="{@title}" data-id="{@uuid}" loading="lazy"/>

--- a/resources/templates/image-preview.blade.php
+++ b/resources/templates/image-preview.blade.php
@@ -1,1 +1,1 @@
-<img class="FoFUpload--Upl-Image-Preview" src="{@url}" title="{@title}" alt="{@title}" data-id="{@uuid}" loading="lazy"/>
+<img class="FoFUpload--Upl-Image-Preview" src="{@url}" title="{@title}" alt="{@alt}" data-id="{@uuid}" loading="lazy"/>

--- a/src/Adapters/AwsS3.php
+++ b/src/Adapters/AwsS3.php
@@ -45,6 +45,7 @@ class AwsS3 extends Flysystem implements UploadAdapter
      * Generate the URL for the given file.
      *
      * @param File $file
+     *
      * @return void
      */
     protected function generateUrl(File $file): void
@@ -57,8 +58,9 @@ class AwsS3 extends Flysystem implements UploadAdapter
     /**
      * Determine the hostname of the storage adapter.
      *
-     * @return string
      * @throws \RuntimeException If the adapter is not an instance of AwsS3Adapter.
+     *
+     * @return string
      */
     public function hostName(): string
     {
@@ -82,6 +84,6 @@ class AwsS3 extends Flysystem implements UploadAdapter
             return sprintf('https://%s.s3.%s.amazonaws.com', $bucket, $region ?: 'us-east-1');
         }
 
-        throw new \RuntimeException('Expected adapter to be an instance of AwsS3Adapter, got ' . get_class($this->adapter));
+        throw new \RuntimeException('Expected adapter to be an instance of AwsS3Adapter, got '.get_class($this->adapter));
     }
 }

--- a/src/Adapters/AwsS3.php
+++ b/src/Adapters/AwsS3.php
@@ -12,7 +12,6 @@
 
 namespace FoF\Upload\Adapters;
 
-use Flarum\Settings\SettingsRepositoryInterface;
 use FoF\Upload\Contracts\UploadAdapter;
 use FoF\Upload\File;
 use Illuminate\Support\Arr;
@@ -20,51 +19,69 @@ use League\Flysystem\AdapterInterface;
 use League\Flysystem\AwsS3v3\AwsS3Adapter;
 use League\Flysystem\Config;
 
+/**
+ * @method hostName() This is only available on the AWS S3 adapter at present.
+ */
 class AwsS3 extends Flysystem implements UploadAdapter
 {
     protected AdapterInterface $adapter;
 
+    /**
+     * Get the configuration settings for the S3 adapter.
+     *
+     * @return Config
+     */
     protected function getConfig(): Config
     {
-        /** @var SettingsRepositoryInterface $settings */
-        $settings = resolve(SettingsRepositoryInterface::class);
-
         $config = new Config();
-        if ($acl = $settings->get('fof-upload.awsS3ACL')) {
+        if ($acl = $this->settings->get('fof-upload.awsS3ACL')) {
             $config->set('ACL', $acl);
         }
 
         return $config;
     }
 
+    /**
+     * Generate the URL for the given file.
+     *
+     * @param File $file
+     * @return void
+     */
     protected function generateUrl(File $file): void
     {
-        /** @var SettingsRepositoryInterface $settings */
-        $settings = resolve(SettingsRepositoryInterface::class);
+        $host = $this->hostName();
 
+        $file->url = sprintf('%s/%s', rtrim($host, '/'), Arr::get($this->meta, 'path', $file->path));
+    }
+
+    /**
+     * Determine the hostname of the storage adapter.
+     *
+     * @return string
+     * @throws \RuntimeException If the adapter is not an instance of AwsS3Adapter.
+     */
+    public function hostName(): string
+    {
         // Fetch custom S3 URL from settings
-        $customUrl = $settings->get('fof-upload.awsS3CustomUrl');
-
+        $customUrl = $this->settings->get('fof-upload.awsS3CustomUrl');
         if (!empty($customUrl)) {
-            // Use custom S3 URL if provided
-            $file->url = sprintf('%s/%s', rtrim($customUrl, '/'), Arr::get($this->meta, 'path', $file->path));
-        } else {
-            // Fallback to default URL construction if no custom URL is provided
-            $cdnUrl = (string) $settings->get('fof-upload.cdnUrl');
-
-            if (!$cdnUrl) {
-                // Ensure that $this->adapter is an instance of AwsS3Adapter
-                if ($this->adapter instanceof AwsS3Adapter) {
-                    $region = $this->adapter->getClient()->getRegion();
-                    $bucket = $this->adapter->getBucket();
-
-                    $cdnUrl = sprintf('https://%s.s3.%s.amazonaws.com', $bucket, $region ?: 'us-east-1');
-                } else {
-                    throw new \RuntimeException('Expected adapter to be an instance of AwsS3Adapter, got '.$this->adapter::class);
-                }
-            }
-
-            $file->url = sprintf('%s/%s', $cdnUrl, Arr::get($this->meta, 'path', $file->path));
+            return $customUrl;
         }
+
+        // Fallback to default URL construction if no custom URL is provided
+        $cdnUrl = (string) $this->settings->get('fof-upload.cdnUrl');
+        if (!empty($cdnUrl)) {
+            return $cdnUrl;
+        }
+
+        // Ensure that $this->adapter is an instance of AwsS3Adapter
+        if ($this->adapter instanceof AwsS3Adapter) {
+            $region = $this->adapter->getClient()->getRegion();
+            $bucket = $this->adapter->getBucket();
+
+            return sprintf('https://%s.s3.%s.amazonaws.com', $bucket, $region ?: 'us-east-1');
+        }
+
+        throw new \RuntimeException('Expected adapter to be an instance of AwsS3Adapter, got ' . get_class($this->adapter));
     }
 }

--- a/src/Adapters/Flysystem.php
+++ b/src/Adapters/Flysystem.php
@@ -13,6 +13,8 @@
 namespace FoF\Upload\Adapters;
 
 use Carbon\Carbon;
+use Flarum\Http\UrlGenerator;
+use Flarum\Settings\SettingsRepositoryInterface;
 use FoF\Upload\Contracts\UploadAdapter;
 use FoF\Upload\File;
 use League\Flysystem\AdapterInterface;
@@ -28,6 +30,8 @@ abstract class Flysystem implements UploadAdapter
 
     public function __construct(
         protected AdapterInterface $adapter,
+        protected SettingsRepositoryInterface $settings,
+        protected UrlGenerator $url
     ) {
     }
 

--- a/src/Adapters/Local.php
+++ b/src/Adapters/Local.php
@@ -13,8 +13,6 @@
 namespace FoF\Upload\Adapters;
 
 use Flarum\Foundation\Paths;
-use Flarum\Http\UrlGenerator;
-use Flarum\Settings\SettingsRepositoryInterface;
 use FoF\Upload\Contracts\UploadAdapter;
 use FoF\Upload\File;
 use League\Flysystem\Adapter\Local as AdapterLocal;
@@ -54,16 +52,10 @@ class Local extends Flysystem implements UploadAdapter
             $this->adapter->applyPathPrefix($this->meta['path'])
         );
 
-        /** @var UrlGenerator $generator */
-        $generator = resolve(UrlGenerator::class);
-
-        /** @var SettingsRepositoryInterface $settings */
-        $settings = resolve(SettingsRepositoryInterface::class);
-
-        if ($settings->get('fof-upload.cdnUrl')) {
-            $file->url = $settings->get('fof-upload.cdnUrl').$file->url;
+        if ($this->settings->get('fof-upload.cdnUrl')) {
+            $file->url = $this->settings->get('fof-upload.cdnUrl').$file->url;
         } else {
-            $file->url = $generator->to('forum')->path(ltrim($file->url, '/'));
+            $file->url = $this->url->to('forum')->path(ltrim($file->url, '/'));
         }
     }
 }

--- a/src/Adapters/Manager.php
+++ b/src/Adapters/Manager.php
@@ -39,7 +39,8 @@ class Manager
         protected Util $util,
         protected SettingsRepositoryInterface $settings,
         protected UrlGenerator $url
-    ) {}
+    ) {
+    }
 
     public function adapters(): Collection
     {
@@ -126,7 +127,7 @@ class Manager
             new Guzzle([
                 'base_uri' => 'https://api.imgur.com/3/',
                 'headers'  => [
-                    'Authorization' => 'Client-ID ' . $this->settings->get('fof-upload.imgurClientId'),
+                    'Authorization' => 'Client-ID '.$this->settings->get('fof-upload.imgurClientId'),
                 ],
             ]),
             $this->settings,
@@ -142,7 +143,7 @@ class Manager
     protected function local(Util $util)
     {
         return new Adapters\Local(
-            new FlyAdapters\Local($this->paths->public . '/assets/files'),
+            new FlyAdapters\Local($this->paths->public.'/assets/files'),
             $this->settings,
             $this->url
         );

--- a/src/Adapters/Manager.php
+++ b/src/Adapters/Manager.php
@@ -129,9 +129,7 @@ class Manager
                 'headers'  => [
                     'Authorization' => 'Client-ID '.$this->settings->get('fof-upload.imgurClientId'),
                 ],
-            ]),
-            $this->settings,
-            $this->url
+            ])
         );
     }
 

--- a/src/Adapters/Qiniu.php
+++ b/src/Adapters/Qiniu.php
@@ -13,7 +13,6 @@
 namespace FoF\Upload\Adapters;
 
 use Flarum\Foundation\ValidationException;
-use Flarum\Settings\SettingsRepositoryInterface;
 use FoF\Upload\Contracts\UploadAdapter;
 use FoF\Upload\File;
 
@@ -21,11 +20,8 @@ class Qiniu extends Flysystem implements UploadAdapter
 {
     protected function generateUrl(File $file): void
     {
-        /** @var SettingsRepositoryInterface $settings */
-        $settings = resolve(SettingsRepositoryInterface::class);
-
         $path = $file->getAttribute('path');
-        if ($cdnUrl = $settings->get('fof-upload.cdnUrl')) {
+        if ($cdnUrl = $this->settings->get('fof-upload.cdnUrl')) {
             $file->url = sprintf('%s/%s', $cdnUrl, $path);
         } else {
             throw new ValidationException(['upload' => 'QiNiu cloud CDN address is not configured.']);

--- a/src/Extenders/AddPostDownloadTags.php
+++ b/src/Extenders/AddPostDownloadTags.php
@@ -48,6 +48,7 @@ class AddPostDownloadTags extends Formatter
                 $template->bbcode(),
                 $template->template()->render()
             );
+            
         } catch (InvalidArgumentException $e) {
             throw new InvalidArgumentException("Failed importing $name due to {$e->getMessage()}");
         } catch (UnsafeTemplateException $e) {

--- a/src/Extenders/AddPostDownloadTags.php
+++ b/src/Extenders/AddPostDownloadTags.php
@@ -48,7 +48,6 @@ class AddPostDownloadTags extends Formatter
                 $template->bbcode(),
                 $template->template()->render()
             );
-            
         } catch (InvalidArgumentException $e) {
             throw new InvalidArgumentException("Failed importing $name due to {$e->getMessage()}");
         } catch (UnsafeTemplateException $e) {

--- a/src/File.php
+++ b/src/File.php
@@ -86,6 +86,12 @@ class File extends AbstractModel
             ->where('uuid', $uuid);
     }
 
+    public static function byUrl(string $url): Builder
+    {
+        return static::query()
+            ->where('url', $url);
+    }
+
     public function actor()
     {
         return $this->belongsTo(User::class, 'actor_id');

--- a/src/Formatter/ImagePreview/FormatImagePreview.php
+++ b/src/Formatter/ImagePreview/FormatImagePreview.php
@@ -12,7 +12,6 @@
 
 namespace FoF\Upload\Formatter\ImagePreview;
 
-use Flarum\Foundation\Paths;
 use FoF\Upload\Repositories\FileRepository;
 use Illuminate\Support\Arr;
 use s9e\TextFormatter\Renderer;
@@ -21,8 +20,7 @@ use s9e\TextFormatter\Utils;
 class FormatImagePreview
 {
     public function __construct(
-        private FileRepository $files,
-        private Paths $paths
+        private FileRepository $files
     ) {
     }
 

--- a/src/Formatter/ImagePreview/FormatImagePreview.php
+++ b/src/Formatter/ImagePreview/FormatImagePreview.php
@@ -46,7 +46,11 @@ class FormatImagePreview
             }
 
             if ($file) {
-                $attributes['url'] = $this->files->getUrlForFile($file);
+
+                if ($fileUrl = $this->files->getUrlForFile($file)) {
+                    $attributes['url'] = $fileUrl;
+                }
+
                 $attributes['title'] = $file->base_name;
             }
 

--- a/src/Formatter/ImagePreview/FormatImagePreview.php
+++ b/src/Formatter/ImagePreview/FormatImagePreview.php
@@ -51,6 +51,10 @@ class FormatImagePreview
                     $attributes['url'] = $fileUrl;
                 }
 
+                if ($attributes['alt'] === "{TEXT?}") {
+                    $attributes['alt'] = "";
+                }
+
                 $attributes['title'] = $file->base_name;
             }
 

--- a/src/Formatter/ImagePreview/FormatImagePreview.php
+++ b/src/Formatter/ImagePreview/FormatImagePreview.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of fof/upload.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ * Copyright (c) Flagrow.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Upload\Formatter\ImagePreview;
+
+use Flarum\Foundation\Paths;
+use FoF\Upload\Repositories\FileRepository;
+use Illuminate\Support\Arr;
+use s9e\TextFormatter\Renderer;
+use s9e\TextFormatter\Utils;
+
+class FormatImagePreview
+{
+    public function __construct(
+        private FileRepository $files,
+        private Paths $paths
+    ) {
+    }
+
+    /**
+     * Configure rendering for image preview uploads.
+     *
+     * @param Renderer $renderer
+     * @param mixed    $context
+     * @param string   $xml
+     *
+     * @return string $xml to be rendered
+     */
+    public function __invoke(Renderer $renderer, $context, string $xml)
+    {
+        return Utils::replaceAttributes($xml, 'UPL-IMAGE-PREVIEW', function ($attributes) {
+            $url = Arr::get($attributes, 'url');
+            $uuid = Arr::get($attributes, 'uuid');
+
+            if ($uuid) {
+                $file = $this->files->findByUuid($uuid);
+            } else {
+                $file = $this->files->findByUrl($url);
+            }
+
+            if ($file) {
+                $attributes['url'] = $this->files->getUrlForFile($file);
+                $attributes['title'] = $file->base_name;
+            }
+
+            return $attributes;
+        });
+    }
+}

--- a/src/Formatter/ImagePreview/FormatImagePreview.php
+++ b/src/Formatter/ImagePreview/FormatImagePreview.php
@@ -46,13 +46,12 @@ class FormatImagePreview
             }
 
             if ($file) {
-
                 if ($fileUrl = $this->files->getUrlForFile($file)) {
                     $attributes['url'] = $fileUrl;
                 }
 
-                if ($attributes['alt'] === "{TEXT?}") {
-                    $attributes['alt'] = "";
+                if ($attributes['alt'] === '{TEXT?}') {
+                    $attributes['alt'] = '';
                 }
 
                 $attributes['title'] = $file->base_name;

--- a/src/Repositories/FileRepository.php
+++ b/src/Repositories/FileRepository.php
@@ -16,6 +16,7 @@ use Carbon\Carbon;
 use enshrined\svgSanitize\Sanitizer;
 use Flarum\Foundation\Paths;
 use Flarum\Foundation\ValidationException;
+use Flarum\Http\UrlGenerator;
 use Flarum\Post\Post;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\User;
@@ -42,7 +43,6 @@ use SoftCreatR\MimeDetector\MimeDetector;
 use SoftCreatR\MimeDetector\MimeDetectorException;
 use Symfony\Component\HttpFoundation\File\UploadedFile as Upload;
 use Symfony\Contracts\Translation\TranslatorInterface;
-use Flarum\Http\UrlGenerator;
 
 class FileRepository
 {
@@ -416,7 +416,7 @@ class FileRepository
     {
         if ($adapter instanceof AwsS3) {
             return $adapter->hostName();
-        } else if ($adapter instanceof Adapters\Local) {
+        } elseif ($adapter instanceof Adapters\Local) {
             return $this->url->to('forum')->path('assets/files');
         }
 

--- a/src/Repositories/FileRepository.php
+++ b/src/Repositories/FileRepository.php
@@ -132,7 +132,7 @@ class FileRepository
          * Fatal error: Uncaught Laminas\HttpHandlerRunner\Exception\EmitterException:
          * Output has been emitted previously; cannot emit response
          */
-        $tempFile = @tempnam($this->path . '/tmp', 'fof.upload.');
+        $tempFile = @tempnam($this->path.'/tmp', 'fof.upload.');
         $upload->moveTo($tempFile);
 
         $file = new Upload(
@@ -251,10 +251,10 @@ class FileRepository
 
         File::query()
             // Files already mapped to the post.
-            ->whereHas('posts', fn($query) => $query->where('posts.id', $post->id))
+            ->whereHas('posts', fn ($query) => $query->where('posts.id', $post->id))
             // Files found in (new) content.
             ->orWhereExists(
-                fn($query) => $query
+                fn ($query) => $query
                     ->select($db->raw(1))
                     ->from('posts')
                     ->where('posts.id', $post->id)
@@ -381,7 +381,7 @@ class FileRepository
             }
 
             return mime_content_type($file->getPathname());
-        } catch (MimeDetectorException | \Exception $e) {
+        } catch (MimeDetectorException|\Exception $e) {
             throw new ValidationException(['upload' => $this->translator->trans('fof-upload.api.upload_errors.could_not_detect_mime')]);
         }
     }
@@ -390,7 +390,7 @@ class FileRepository
     {
         $today = (new Carbon());
 
-        $path = $today->timestamp . '-' . $today->micro . '-' . $file->base_name;
+        $path = $today->timestamp.'-'.$today->micro.'-'.$file->base_name;
 
         return $withFolder ? sprintf(
             '%s%s%s',
@@ -402,11 +402,11 @@ class FileRepository
 
     /**
      * Determine the hostname for the adapter used for this file.
-     * 
+     *
      * Currently only available for AwsS3.
-     * 
+     *
      * @param File $file
-     * 
+     *
      * @returns string|null
      */
     public function getHostnameForFile(File $file): ?string
@@ -422,12 +422,13 @@ class FileRepository
 
     /**
      * Build and return the absolute URL for a file.
-     * 
+     *
      * @param File $file
+     *
      * @returns string|null
      */
     public function getUrlForFile(File $file): ?string
     {
-        return $this->getHostnameForFile($file) . '/' . $file->path;
+        return $this->getHostnameForFile($file).'/'.$file->path;
     }
 }

--- a/src/Templates/ImagePreviewTemplate.php
+++ b/src/Templates/ImagePreviewTemplate.php
@@ -47,6 +47,6 @@ class ImagePreviewTemplate extends AbstractTextFormatterTemplate
      */
     public function bbcode(): string
     {
-        return '[upl-image-preview url={URL}]';
+        return '[upl-image-preview uuid={IDENTIFIER} url={URL?}]';
     }
 }

--- a/src/Templates/ImagePreviewTemplate.php
+++ b/src/Templates/ImagePreviewTemplate.php
@@ -47,6 +47,6 @@ class ImagePreviewTemplate extends AbstractTextFormatterTemplate
      */
     public function bbcode(): string
     {
-        return '[upl-image-preview uuid={IDENTIFIER} url={URL?}]';
+        return '[upl-image-preview uuid={IDENTIFIER} url={URL?} alt={TEXT?}]';
     }
 }


### PR DESCRIPTION
The general purpose of this is to move away from having a single CDN prefix defined in the extension settings, thus allowing multiple adapters to have different hosts.

Also, the storing of the absolute url IMO is bad practice, and this should be generated based on the specific adapter settings.

We cannot clean all of this up without a major breaking change, so this PR starts the process by allowing either the old url or the new uuid parameters.