### PR TITLE
fix: change mimetype default in admin UI

### DIFF
--- a/js/src/admin/components/UploadPage.js
+++ b/js/src/admin/components/UploadPage.js
@@ -96,7 +96,7 @@ export default class UploadPage extends ExtensionPage {
     this.defaultAdap = Object.keys(this.uploadMethodOptions)[Object.keys(this.uploadMethodOptions).length - 1];
     this.values.mimeTypes() ||
       (this.values.mimeTypes = Stream({
-        '^image\\/.*': {
+        '^image\\/(jpeg|png|gif|webp|avif|bmp|tiff|svg\\+xml)$': {
           adapter: this.defaultAdap,
           template: 'image-preview',
         },


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

Default Mime Types in the Admin UI still shows `^image\/.*` instead of `^image\/(jpeg|png|gif|webp|avif|bmp|tiff|svg\+xml)$`. See #429 

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
