### PR TITLE
fix: resolve deprecation warning

### DIFF
--- a/src/Adapters/Flysystem.php
+++ b/src/Adapters/Flysystem.php
@@ -52,7 +52,7 @@ abstract class Flysystem implements UploadAdapter
      *
      * @return File|bool
      */
-    public function upload(File $file, ?UploadedFile $upload = null, $contents)
+    public function upload(File $file, ?UploadedFile $upload = null, $contents = null)
     {
         $this->generateFilename($file);
 


### PR DESCRIPTION
Set a default value to $contents to prevent getting warning "PHP Deprecated:  Optional parameter $upload declared before required parameter $contents is implicitly treated as a required parameter"

Fixes #422 