### PR TITLE
[2.x] chore: drop overtrue/flysystem-qiniu from require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
     "require-dev": {
         "league/flysystem-aws-s3-v3": "^3.31",
         "flarum/gdpr": "^2.0.0",
-        "flarum/phpstan": "^2.0.0",
+        "flarum/phpstan": "2.x-dev",
         "flarum/testing": "^2.0.0",
         "flarum/tags": "^2.0.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,6 @@
     },
     "require-dev": {
         "league/flysystem-aws-s3-v3": "^3.31",
-        "overtrue/flysystem-qiniu": "^3.2",
         "flarum/gdpr": "^2.0.0",
         "flarum/phpstan": "^2.0.0",
         "flarum/testing": "^2.0.0",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,3 +9,16 @@ parameters:
   excludePaths:
     - *.blade.php
   databaseMigrationsPath: ['migrations']
+  ignoreErrors:
+    # overtrue/flysystem-qiniu is no longer a dev dependency: qiniu/php-sdk
+    # triggers PHP 8.4 deprecations during bootstrap, which fail the whole
+    # integration suite under processIsolation. The adapter code stays, guarded
+    # by class_exists(), so forums that install the package keep Qiniu support —
+    # but PHPStan can no longer resolve the symbol.
+    #
+    # Remove these once qiniu/php-sdk supports PHP 8.4, or if Qiniu support is
+    # dropped outright.
+    - message: '#Instantiated class Overtrue\\Flysystem\\Qiniu\\QiniuAdapter not found\.#'
+      path: src/Adapters/Manager.php
+    - message: '#Parameter \#1 \$adapter of class FoF\\Upload\\Adapters\\Qiniu constructor expects League\\Flysystem\\FilesystemAdapter, Overtrue\\Flysystem\\Qiniu\\QiniuAdapter given\.#'
+      path: src/Adapters/Manager.php


### PR DESCRIPTION
Every integration test has been erroring on all PRs and on `2.x` itself — 102 errors, zero assertions, so the tests were not running at all.

**Changes proposed in this pull request:**

`qiniu/php-sdk` has 64 implicitly-nullable parameter signatures, including:

```php
// vendor/qiniu/php-sdk/src/Qiniu/Config.php:44
public function __construct(Region $z = null)
```

PHP 8.4 deprecates that form. `Config` is constructed while enumerating adapters, so the deprecation fires during bootstrap on every integration test — and with `processIsolation="true"` PHPUnit treats the child process output as an error. The unit suite is unaffected because it runs with `processIsolation="false"`.

**The library has not changed.** v7.14.0 is from October 2024 and remains the latest release; `dev-master` has not moved since either. Its `composer.json` still declares `php: >=5.3.3`, so an upstream fix looks unlikely. What changed is the PHP version CI runs on — this has been latent since 8.4.

Removing it from `require-dev` is sufficient:

- The Qiniu adapter itself stays. `Manager::adapters()` guards with `class_exists()`, so anyone who installs the package keeps Qiniu support.
- The only test referencing Qiniu (`AdaptersExtenderTest`) asserts it is **absent**, so it still passes.
- The `suggest` entry was already removed separately.

**Reviewers should focus on:**

- Whether dropping dev-time Qiniu coverage is acceptable. There is no test exercising the adapter itself, so nothing is actually lost, but it does mean the code path is no longer installed during CI.

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).

**Testing**

| | Before | After |
| --- | --- | --- |
| Integration | 102 errors, 0 assertions | **102 passing, 343 assertions** |
| Unit | 145 passing | 145 passing |

Three PHP deprecations remain, from `middlewares/utils` via `flarum/core`. Those are reported as deprecations rather than errors, so they do not fail the suite — unlike the Qiniu one, which was fatal because it fires during bootstrap.
