### PR TITLE
[2.x] fix: stop rejecting uploads over two spellings of the same MIME type

### DIFF
--- a/src/Mime/MimeTypeDetector.php
+++ b/src/Mime/MimeTypeDetector.php
@@ -22,6 +22,101 @@ class MimeTypeDetector
     protected ?UploadedFile $upload = null;
 
     /**
+     * Names that denote the same format, mapped onto one representative each.
+     *
+     * getMimeType() cross-checks php-mime-detector against fileinfo and rejects the upload
+     * when the two disagree. They frequently disagree about nothing: a format usually has
+     * more than one registered name, the two libraries picked different ones, and the file
+     * is exactly what it claims to be. A .wav is the common case — php-mime-detector answers
+     * `audio/vnd.wave` (the IANA registration) and libmagic answers `audio/x-wav` (the name
+     * that predates it) — and there is no file either library would accept.
+     *
+     * Merging these affects the cross-check only. getMimeType() still returns the detector's
+     * own spelling, so the admin's MIME whitelist and the extension mapping see exactly what
+     * they saw before.
+     *
+     * Nothing here crosses a format boundary, so the check keeps its purpose: a file whose
+     * magic bytes and libmagic signature describe genuinely different formats is still
+     * rejected. The two deliberate groupings are documented where they appear.
+     */
+    protected const EQUIVALENT_MIME_TYPES = [
+        // Audio.
+        'audio/wav'          => 'audio/vnd.wave',
+        'audio/wave'         => 'audio/vnd.wave',
+        'audio/x-wav'        => 'audio/vnd.wave',
+        'audio/x-pn-wav'     => 'audio/vnd.wave',
+        'audio/x-flac'       => 'audio/flac',
+        'audio/x-aiff'       => 'audio/aiff',
+        'audio/x-aifc'       => 'audio/aiff',
+        'audio/m4a'          => 'audio/mp4',
+        'audio/x-m4a'        => 'audio/mp4',
+        'audio/mp3'          => 'audio/mpeg',
+        'audio/x-mp3'        => 'audio/mpeg',
+        'audio/mpeg3'        => 'audio/mpeg',
+        'audio/x-mpeg3'      => 'audio/mpeg',
+        'audio/x-mpeg'       => 'audio/mpeg',
+        'audio/x-ape'        => 'audio/ape',
+        'audio/x-wavpack'    => 'audio/wavpack',
+
+        // Ogg is a container, and the two libraries answer at different levels: libmagic
+        // names the container, php-mime-detector the codec inside it. Same bytes, and the
+        // container is what an admin whitelisting `audio/ogg` means.
+        'audio/x-ogg'        => 'audio/ogg',
+        'audio/opus'         => 'audio/ogg',
+        'audio/vorbis'       => 'audio/ogg',
+        'audio/x-opus+ogg'   => 'audio/ogg',
+        'audio/x-vorbis+ogg' => 'audio/ogg',
+
+        // Video.
+        'video/avi'          => 'video/vnd.avi',
+        'video/msvideo'      => 'video/vnd.avi',
+        'video/x-msvideo'    => 'video/vnd.avi',
+        'video/x-matroska'   => 'video/matroska',
+        'video/mpeg4'        => 'video/mp4',
+        'video/x-m4v'        => 'video/mp4',
+        'video/x-quicktime'  => 'video/quicktime',
+
+        // Images.
+        'image/ico'          => 'image/vnd.microsoft.icon',
+        'image/x-icon'       => 'image/vnd.microsoft.icon',
+        'image/x-ms-bmp'     => 'image/bmp',
+        'image/x-bmp'        => 'image/bmp',
+        'image/x-tiff'       => 'image/tiff',
+        'image/psd'          => 'image/vnd.adobe.photoshop',
+        'image/photoshop'    => 'image/vnd.adobe.photoshop',
+        'image/x-photoshop'  => 'image/vnd.adobe.photoshop',
+
+        // Fonts. TrueType and OpenType share the SFNT container, and libmagic reports some
+        // builds of either as `font/sfnt` without distinguishing them, so the whole family
+        // resolves to one name. TTF against OTF is not a security boundary.
+        'font/ttf'                      => 'font/sfnt',
+        'font/otf'                      => 'font/sfnt',
+        'application/font-sfnt'         => 'font/sfnt',
+        'application/x-font-ttf'        => 'font/sfnt',
+        'application/x-font-truetype'   => 'font/sfnt',
+        'application/x-font-otf'        => 'font/sfnt',
+        'application/x-font-opentype'   => 'font/sfnt',
+        'application/vnd.ms-opentype'   => 'font/sfnt',
+        'application/font-woff'         => 'font/woff',
+        'application/x-font-woff'       => 'font/woff',
+
+        // Documents, archives, executables.
+        'text/rtf'                                      => 'application/rtf',
+        'text/xml'                                      => 'application/xml',
+        'application/x-rar'                             => 'application/x-rar-compressed',
+        'application/vnd.rar'                           => 'application/x-rar-compressed',
+        'application/x-gzip'                            => 'application/gzip',
+        'application/x-bzip'                            => 'application/x-bzip2',
+        'application/x-debian-package'                  => 'application/x-deb',
+        'application/vnd.debian.binary-package'         => 'application/x-deb',
+        'application/x-dosexec'                         => 'application/x-msdownload',
+        'application/x-ms-dos-executable'               => 'application/x-msdownload',
+        'application/vnd.microsoft.portable-executable' => 'application/x-msdownload',
+        'application/x-nes-rom'                         => 'application/x-nintendo-nes-rom',
+        'application/vnd.sqlite3'                       => 'application/x-sqlite3',
+    ];
+
+    /**
      * Set the file path for MIME type detection.
      *
      * @param string $filePath
@@ -77,8 +172,9 @@ class MimeTypeDetector
                     }
                 }
 
-                // Reject if MIME mismatch occurs (AFTER checking for APKs)
-                if ($detectorMime !== $fileinfoMime) {
+                // Reject if MIME mismatch occurs (AFTER checking for APKs), comparing the
+                // formats rather than the strings — see EQUIVALENT_MIME_TYPES.
+                if ($this->canonicalMimeType($detectorMime) !== $this->canonicalMimeType($fileinfoMime)) {
                     $message = "MIME type mismatch detected: $detectorMime vs $fileinfoMime";
                     resolve('log')->error("[fof/upload] $message");
 
@@ -106,6 +202,24 @@ class MimeTypeDetector
         } catch (\Exception $e) {
             throw new ValidationException(['upload' => 'Could not detect MIME type.']);
         }
+    }
+
+    /**
+     * Reduces a MIME type to the name this class compares on.
+     *
+     * Lower-cases it, drops any parameters (`text/xml; charset=utf-8`), and resolves the
+     * alternative spellings in EQUIVALENT_MIME_TYPES onto one representative. An unknown
+     * type is returned unchanged, so a name nobody has listed still has to match exactly.
+     */
+    protected function canonicalMimeType(?string $mime): ?string
+    {
+        if ($mime === null) {
+            return null;
+        }
+
+        $mime = strtolower(trim(explode(';', $mime, 2)[0]));
+
+        return static::EQUIVALENT_MIME_TYPES[$mime] ?? $mime;
     }
 
     /**

--- a/tests/unit/Mime/MimeTypeDetectorTest.php
+++ b/tests/unit/Mime/MimeTypeDetectorTest.php
@@ -14,6 +14,7 @@ namespace FoF\Upload\Tests\unit\Mime;
 
 use Flarum\Foundation\ValidationException;
 use FoF\Upload\Mime\MimeTypeDetector;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -124,5 +125,133 @@ class MimeTypeDetectorTest extends TestCase
         // Must not throw ValidationException.
         $mime = $detector->forFile($path)->getMimeType();
         $this->assertIsString($mime);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Cross-validation between the two detectors compares formats, not spellings.
+
+    /**
+     * A complete, playable 8-sample WAV. php-mime-detector calls it `audio/vnd.wave`,
+     * libmagic calls it `audio/x-wav`, and before the two names were treated as one this
+     * was rejected as a mismatch — no .wav could be uploaded at all.
+     */
+    private function wavBytes(): string
+    {
+        $pcm = str_repeat(pack('v', 0), 8);
+
+        return 'RIFF'.pack('V', 36 + strlen($pcm)).'WAVEfmt '
+            .pack('VvvVVvv', 16, 1, 1, 8000, 16000, 2, 16)
+            .'data'.pack('V', strlen($pcm)).$pcm;
+    }
+
+    #[Test]
+    public function getMimeType_accepts_a_wav_the_two_detectors_spell_differently(): void
+    {
+        if (!MimeTypeDetector::fileinfoAvailable()) {
+            $this->markTestSkipped('fileinfo extension not loaded on this system');
+        }
+
+        $path = $this->makeTempFile($this->wavBytes());
+
+        // Only meaningful where libmagic recognises the file as a WAV under some name.
+        if (!str_contains((string) mime_content_type($path), 'wav')) {
+            $this->markTestSkipped('this libmagic build does not identify WAV files');
+        }
+
+        $mime = (new MimeTypeDetector())->forFile($path)->getMimeType();
+
+        // The detector's own spelling is still what callers get: the whitelist and the
+        // extension mapping must see no change.
+        $this->assertSame('audio/vnd.wave', $mime);
+        $this->assertFileExists($path, 'a rejected upload is deleted; this one was accepted');
+    }
+
+    #[Test]
+    public function getMimeType_still_rejects_a_genuine_mismatch(): void
+    {
+        if (!MimeTypeDetector::fileinfoAvailable()) {
+            $this->markTestSkipped('fileinfo extension not loaded on this system');
+        }
+
+        // FLIF magic bytes in front of an HTML document — the shape of the Polyglot.flif
+        // fixture the integration suite uses. php-mime-detector reads the header and says
+        // image/flif; libmagic reads the body and says text/html. Nothing merges those.
+        $path = $this->makeTempFile("FLIF\x00\x00<!DOCTYPE html><html><body>x</body></html>");
+
+        $this->expectException(ValidationException::class);
+
+        (new MimeTypeDetector())->forFile($path)->getMimeType();
+    }
+
+    public static function equivalentSpellings(): array
+    {
+        return [
+            'wav, IANA vs historic'   => ['audio/vnd.wave', 'audio/x-wav'],
+            'flac, x- on either side' => ['audio/x-flac', 'audio/flac'],
+            'aiff'                    => ['audio/aiff', 'audio/x-aiff'],
+            'm4a as mp4 audio'        => ['audio/mp4', 'audio/x-m4a'],
+            'opus inside ogg'         => ['audio/opus', 'audio/ogg'],
+            'avi'                     => ['video/vnd.avi', 'video/x-msvideo'],
+            'rar'                     => ['application/x-rar-compressed', 'application/x-rar'],
+            'rtf'                     => ['application/rtf', 'text/rtf'],
+            'xml'                     => ['application/xml', 'text/xml'],
+            'debian package'          => ['application/x-deb', 'application/vnd.debian.binary-package'],
+            'sfnt fonts'              => ['font/ttf', 'font/sfnt'],
+            'opentype'                => ['font/otf', 'application/vnd.ms-opentype'],
+            'icon'                    => ['image/x-icon', 'image/vnd.microsoft.icon'],
+            'case and parameters'     => ['text/XML', 'application/xml; charset=utf-8'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('equivalentSpellings')]
+    public function canonicalMimeType_treats_alternative_spellings_as_one(string $a, string $b): void
+    {
+        $detector = $this->exposedDetector();
+
+        $this->assertSame($detector->canonical($a), $detector->canonical($b), "$a and $b name the same format");
+    }
+
+    public static function distinctFormats(): array
+    {
+        return [
+            'header lies about the body' => ['image/flif', 'text/html'],
+            'image against document'     => ['image/png', 'application/pdf'],
+            'svg is not just xml'        => ['image/svg+xml', 'application/xml'],
+            'html is not plain text'     => ['text/html', 'text/plain'],
+            'archive against image'      => ['application/zip', 'image/jpeg'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('distinctFormats')]
+    public function canonicalMimeType_keeps_different_formats_apart(string $a, string $b): void
+    {
+        $detector = $this->exposedDetector();
+
+        $this->assertNotSame($detector->canonical($a), $detector->canonical($b), "$a and $b are different formats");
+    }
+
+    #[Test]
+    public function canonicalMimeType_passes_through_an_unlisted_type(): void
+    {
+        $detector = $this->exposedDetector();
+
+        $this->assertSame('application/x-made-up', $detector->canonical('application/x-made-up'));
+        $this->assertNull($detector->canonical(null));
+    }
+
+    /**
+     * canonicalMimeType() is protected; this exposes it without changing its visibility
+     * in the class under test.
+     */
+    private function exposedDetector(): MimeTypeDetector
+    {
+        return new class() extends MimeTypeDetector {
+            public function canonical(?string $mime): ?string
+            {
+                return $this->canonicalMimeType($mime);
+            }
+        };
     }
 }


### PR DESCRIPTION
Fixes #514.

## The problem

`getMimeType()` cross-validates php-mime-detector against fileinfo and rejects the upload whenever the two answers are not the same string. Most formats have more than one registered name, and the two libraries did not always pick the same one, so a file that is exactly what it claims to be is deleted and the member is shown `MIME type mismatch detected: audio/vnd.wave vs audio/x-wav`.

`.wav` is the case that surfaced it — `audio/vnd.wave` is the IANA registration, `audio/x-wav` is the name that predates it, and no `.wav` exists for which the two libraries answer differently, so the format is unavailable on every install. Measuring the rest of the surface (real files wherever a header is not enough; samples fileinfo could not identify at all discarded), **13 of 34 identifiable formats are rejected unconditionally** on PHP 8.4 / libmagic 5.45: wav, flac, aiff, m4a, opus, avi, rar v4 and v5, rtf, xml, ttf, ico, deb. Issue #514 has the full table.

## The fix

Compare the formats, not the strings.

- `EQUIVALENT_MIME_TYPES` maps alternative spellings onto one representative each; `canonicalMimeType()` applies it, after lower-casing and dropping any parameters, so `text/XML; charset=utf-8` no longer differs from `text/xml`. A name that is not in the table is returned unchanged, so anything nobody has listed still has to match exactly.
- The comparison is the only thing that changes. `getMimeType()` still returns `$detectorMime` — the detector's own spelling — so the admin's MIME whitelist and the extension mapping see exactly what they saw before.
- The table is a `protected const` read through `static::`, so an install with an unusual libmagic build can extend it in a subclass.

Two groupings are wider than pure synonyms, and are commented where they appear:

- **Ogg.** libmagic names the container (`audio/ogg`), php-mime-detector the codec inside it (`audio/opus`). Same bytes, and the container is what an admin whitelisting `audio/ogg` means.
- **SFNT fonts.** TrueType and OpenType share the container, and some libmagic builds report `font/sfnt` for either without distinguishing them. TTF against OTF is not a security boundary.

## Why this doesn't weaken the check

Nothing in the table crosses a format boundary, so a file whose magic bytes and whose libmagic signature describe genuinely different formats is still rejected.

I ran every fixture in `tests/fixtures` through both the current class and the patched one, on Ubuntu 24.04 / libmagic 5.45:

| fixture | 2.x today | with the fix |
|---|---|---|
| Polyglot.flif | REJECTED | REJECTED |
| Polyglot.jpg | `text/html` | `text/html` |
| SpoofedMime.png | `text/html` | `text/html` |
| TextFileWithPngExtension.png | `text/plain` | `text/plain` |
| Malicious.html | `text/html` | `text/html` |
| Malicious.svg / Safe.svg | `image/svg+xml` | `image/svg+xml` |
| Example.apk | `application/vnd.android.package-archive` | same |
| Document.pdf / Example.zip / *.jpg / Plain.txt | unchanged | unchanged |

Identical in every row. `Polyglot.flif` is the one the mismatch branch actually catches, and it still does: `image/flif` against `text/html` is a real disagreement. The other malicious fixtures are caught downstream by the whitelist, as they are today.

And the formats that change, same harness:

| | 2.x today | with the fix |
|---|---|---|
| wav | REJECTED | `audio/vnd.wave` |
| flac | REJECTED | `audio/x-flac` |
| aiff | REJECTED | `audio/aiff` |
| m4a | REJECTED | `audio/mp4` |
| opus | REJECTED | `audio/opus` |
| avi | REJECTED | `video/vnd.avi` |
| rar v4 / v5 | REJECTED | `application/x-rar-compressed` |
| rtf | REJECTED | `application/rtf` |
| xml | REJECTED | `application/xml` |
| ttf | REJECTED | `font/ttf` |
| ico | REJECTED | `image/x-icon` |
| deb | REJECTED | `application/x-deb` |

13 formats go from rejected to accepted; none go the other way, and every returned value is the detector's own spelling, unchanged from what the whitelist matched against before.

## Tests

Added to `tests/unit/Mime/MimeTypeDetectorTest.php`:

- a real WAV round-trip, asserting both that it is accepted and that `audio/vnd.wave` is still what callers get — this one fails on 2.x today;
- a genuine mismatch (FLIF header, HTML body — the shape of the `Polyglot.flif` fixture) that must still be rejected;
- the equivalence table in both directions, as data providers: 14 pairs of spellings that must merge, 5 pairs of formats that must stay apart, plus pass-through of an unlisted type and of `null`.

`composer test:unit` 167/167 green, PHPStan level 6 clean. The two libmagic-dependent tests skip themselves where fileinfo is missing or does not identify a WAV.

No frontend change, so no `js/dist`.
